### PR TITLE
feat(build): stage-b failure containment

### DIFF
--- a/src/sema/cli.py
+++ b/src/sema/cli.py
@@ -69,6 +69,10 @@ def cli() -> None:
     "--materialize-structural-fk", is_flag=True, default=False,
     help="Lower materialization threshold to 0.70 so Tier-3 (name+type only) FK candidates promote to JoinPath nodes",
 )
+@click.option(
+    "--no-quality-budget", is_flag=True, default=False,
+    help="Disable both run-level quality budget triggers (graph-health and run-reliability)",
+)
 @click.option("--verbose", is_flag=True, default=False, help="Enable verbose output")
 def build(
     source: str | None,
@@ -88,6 +92,7 @@ def build(
     resume: bool,
     enable_fk_detection: bool,
     materialize_structural_fk: bool,
+    no_quality_budget: bool,
     verbose: bool,
 ) -> None:
     """Build the knowledge graph from a data source."""
@@ -104,6 +109,9 @@ def build(
         materialize_structural_fk=materialize_structural_fk,
         verbose=verbose,
     )
+    if no_quality_budget:
+        build_config.quality_budget_max_failure_rate = 1.0
+        build_config.quality_budget_max_non_contributing_rate = 1.0
     try:
         report = run_build(build_config)
         click.echo("\nBuild Report")
@@ -125,6 +133,10 @@ def build(
             else:
                 click.echo(f"  {label}: {value}")
     except Exception as e:
+        from sema.pipeline.quality_budget import QualityBudgetExceeded
+        if isinstance(e, QualityBudgetExceeded):
+            click.echo(f"Quality budget exceeded: {e}", err=True)
+            sys.exit(7)
         click.echo(f"Error: {e}", err=True)
         sys.exit(1)
 

--- a/src/sema/engine/metadata_tier.py
+++ b/src/sema/engine/metadata_tier.py
@@ -1,0 +1,68 @@
+"""Source-agnostic metadata-tier classifier.
+
+Classifies a table into `rich` / `sparse` / `name_only` from its L1
+evidence shape — never from schema names, source types, or per-source
+allowlists. Pure: no I/O, no LLM, no side effects.
+"""
+from __future__ import annotations
+
+from typing import Any, Literal
+
+Tier = Literal["rich", "sparse", "name_only"]
+
+_TOP_VALUES_MAJORITY_FLOOR = 0.50
+_DEFAULT_RICH_COMMENT_FLOOR = 0.60
+
+
+def _column_comment_coverage(columns: list[dict[str, Any]]) -> float:
+    if not columns:
+        return 0.0
+    with_comments = sum(
+        1 for c in columns
+        if (c.get("column_comment") or c.get("comment") or "").strip()
+    )
+    return with_comments / len(columns)
+
+
+def _top_values_coverage(columns: list[dict[str, Any]]) -> float:
+    if not columns:
+        return 0.0
+    with_top = sum(
+        1 for c in columns if c.get("top_values")
+    )
+    return with_top / len(columns)
+
+
+def classify_metadata_tier(
+    evidence: dict[str, Any],
+    *,
+    rich_floor: float = _DEFAULT_RICH_COMMENT_FLOOR,
+) -> Tier:
+    columns = evidence.get("columns") or []
+    table_comment = (
+        evidence.get("table_comment")
+        or evidence.get("comment")
+        or ""
+    ).strip()
+    sample_rows = evidence.get("sample_rows") or []
+
+    comment_cov = _column_comment_coverage(columns)
+    top_cov = _top_values_coverage(columns)
+    has_supporting = (
+        bool(table_comment)
+        or top_cov >= _TOP_VALUES_MAJORITY_FLOOR
+        or bool(sample_rows)
+    )
+
+    if comment_cov >= rich_floor and has_supporting:
+        return "rich"
+
+    has_any_evidence = (
+        comment_cov > 0
+        or bool(table_comment)
+        or top_cov > 0
+        or bool(sample_rows)
+    )
+    if has_any_evidence:
+        return "sparse"
+    return "name_only"

--- a/src/sema/engine/semantic.py
+++ b/src/sema/engine/semantic.py
@@ -9,6 +9,11 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
+from sema.engine.semantic_utils import (
+    LLMAttempt,
+    hash_prompt,
+    stringify_response,
+)
 from sema.engine.stage_utils import (
     PromptLayers,
     build_stage_a_prompt,
@@ -22,7 +27,7 @@ from sema.engine.stage_utils import (
     sanitize_column_name,
     should_trigger_stage_c,
 )
-from sema.llm_client import LLMStageError
+from sema.llm_client import LLMStageError, StageBFailureError
 from sema.models.assertions import (
     Assertion,
     AssertionPredicate,
@@ -68,12 +73,51 @@ class SemanticEngine:
         column_batch_size: int = 25,
         domain_context: DomainContext | None = None,
         prompt_layers: PromptLayers | None = None,
+        capture_llm_attempts: bool = False,
+        metadata_tier: str = "rich",
+        partial_coverage_floor: float = 0.60,
     ) -> None:
         self._llm_client = llm_client
         self._run_id = run_id or str(uuid.uuid4())
         self._column_batch_size = column_batch_size
         self._domain_context = domain_context
         self._layers = prompt_layers or PromptLayers()
+        self._capture_attempts = capture_llm_attempts
+        self._llm_attempts: list[LLMAttempt] = []
+        self._metadata_tier = metadata_tier
+        self._partial_coverage_floor = partial_coverage_floor
+
+    def snapshot_llm_attempts(self) -> list[LLMAttempt]:
+        """Return a shallow copy of the per-table attempt buffer."""
+        return list(self._llm_attempts)
+
+    def _record_attempt(
+        self,
+        stage: str,
+        prompt: str,
+        batch_index: int | None,
+    ) -> LLMAttempt | None:
+        if not self._capture_attempts:
+            return None
+        attempt = LLMAttempt(
+            stage=stage,
+            batch_index=batch_index,
+            prompt_text=prompt,
+            prompt_hash=hash_prompt(prompt),
+            raw_response=None,
+            parsed_ok=False,
+        )
+        self._llm_attempts.append(attempt)
+        return attempt
+
+    def _finalize_attempt(
+        self, attempt: LLMAttempt | None, parsed_ok: bool,
+    ) -> None:
+        if attempt is None:
+            return
+        raw = getattr(self._llm_client, "last_response", None)
+        attempt.raw_response = stringify_response(raw)
+        attempt.parsed_ok = parsed_ok
 
     def run_stage_a(
         self, table_metadata: dict[str, Any],
@@ -91,12 +135,23 @@ class SemanticEngine:
             table_metadata, domain_context=self._domain_context,
             layers=self._layers,
         )
-        return self._llm_client.invoke(  # type: ignore[no-any-return]
-            prompt,
-            StageAResult,
-            table_ref=table_ref,
-            stage_name="L2 stage_a",
-        )
+        attempt = self._record_attempt("L2 stage_a", prompt, None)
+        try:
+            result = self._llm_client.invoke(
+                prompt,
+                StageAResult,
+                table_ref=table_ref,
+                stage_name="L2 stage_a",
+            )
+        except LLMStageError as exc:
+            self._finalize_attempt(attempt, parsed_ok=False)
+            exc.llm_attempts = self.snapshot_llm_attempts()
+            raise
+        except Exception:
+            self._finalize_attempt(attempt, parsed_ok=False)
+            raise
+        self._finalize_attempt(attempt, parsed_ok=True)
+        return result  # type: ignore[no-any-return]
 
     def _invoke_stage_b_batch(
         self,
@@ -104,18 +159,29 @@ class SemanticEngine:
         batch: list[dict[str, Any]],
         stage_a: StageAResult,
         table_ref: str,
+        batch_index: int | None = None,
     ) -> StageBBatchResult:
         prompt = build_stage_b_prompt(
             table_metadata, batch, stage_a,
             domain_context=self._domain_context,
             layers=self._layers,
         )
-        result: StageBBatchResult = self._llm_client.invoke(
-            prompt,
-            StageBBatchResult,
-            table_ref=table_ref,
-            stage_name="L2 stage_b",
-        )
+        attempt = self._record_attempt("L2 stage_b", prompt, batch_index)
+        try:
+            result: StageBBatchResult = self._llm_client.invoke(
+                prompt,
+                StageBBatchResult,
+                table_ref=table_ref,
+                stage_name="L2 stage_b",
+            )
+        except LLMStageError as exc:
+            self._finalize_attempt(attempt, parsed_ok=False)
+            exc.llm_attempts = self.snapshot_llm_attempts()
+            raise
+        except Exception:
+            self._finalize_attempt(attempt, parsed_ok=False)
+            raise
+        self._finalize_attempt(attempt, parsed_ok=True)
         for c in result.columns:
             c.column = sanitize_column_name(c.column)
         return result
@@ -126,6 +192,7 @@ class SemanticEngine:
         batch: list[dict[str, Any]],
         stage_a: StageAResult,
         table_ref: str,
+        batch_index: int = 0,
     ) -> tuple[list[StageBBatchResult], list[dict[str, Any]], int, int]:
         """Run a batch with bounded recovery: retry once, split once.
 
@@ -137,22 +204,22 @@ class SemanticEngine:
         try:
             result = self._invoke_stage_b_batch(
                 table_metadata, batch, stage_a, table_ref,
+                batch_index=batch_index,
             )
             return [result], [], retries, splits
         except LLMStageError:
             pass
 
-        # Retry once
         retries += 1
         try:
             result = self._invoke_stage_b_batch(
                 table_metadata, batch, stage_a, table_ref,
+                batch_index=batch_index,
             )
             return [result], [], retries, splits
         except LLMStageError:
             pass
 
-        # Split into two halves — no further recovery on sub-batches
         if len(batch) < 2:
             return [], batch, retries, splits
 
@@ -164,6 +231,7 @@ class SemanticEngine:
             try:
                 r = self._invoke_stage_b_batch(
                     table_metadata, half, stage_a, table_ref,
+                    batch_index=batch_index,
                 )
                 results.append(r)
             except LLMStageError:
@@ -185,6 +253,7 @@ class SemanticEngine:
         try:
             result = self._invoke_stage_b_batch(
                 table_metadata, crit_batch, stage_a, table_ref,
+                batch_index=None,
             )
             remaining = [c for c in failed_cols if c["name"] not in critical]
             return [result], remaining
@@ -214,13 +283,16 @@ class SemanticEngine:
         total_splits = 0
         rescues_used = 0
 
+        batch_idx = 0
         for i in range(0, len(columns), self._column_batch_size):
             batch = columns[i:i + self._column_batch_size]
             results, failed, retries, splits = (
                 self._run_batch_with_recovery(
                     table_metadata, batch, stage_a, table_ref,
+                    batch_index=batch_idx,
                 )
             )
+            batch_idx += 1
             all_batches.extend(results)
             all_failed.extend(failed)
             total_retries += retries
@@ -282,6 +354,8 @@ class SemanticEngine:
             raw_coverage=raw_cov,
             critical_coverage=crit_cov,
             unresolved=unresolved,
+            metadata_tier=self._metadata_tier,
+            partial_coverage_floor=self._partial_coverage_floor,
         )
 
         return StageBResult(
@@ -359,6 +433,7 @@ class SemanticEngine:
             domain_context=self._domain_context,
             layers=self._layers,
         )
+        attempt = self._record_attempt("L2 stage_c", prompt, None)
         try:
             batch_result = self._llm_client.invoke(
                 prompt,
@@ -366,16 +441,18 @@ class SemanticEngine:
                 table_ref=table_ref,
                 stage_name="L2 stage_c",
             )
-            for cr in batch_result.columns:
-                results[cr.column] = cr
-        except LLMStageError:
-            # Fallback: try per-column on batch failure
+        except LLMStageError as exc:
+            self._finalize_attempt(attempt, parsed_ok=False)
+            exc.llm_attempts = self.snapshot_llm_attempts()
             for entry in prompt_input:
                 col_name = entry["column"]
                 single_prompt = build_stage_c_prompt(
                     [entry], stage_a,
                     domain_context=self._domain_context,
                     layers=self._layers,
+                )
+                single_attempt = self._record_attempt(
+                    "L2 stage_c", single_prompt, None,
                 )
                 try:
                     cr = self._llm_client.invoke(
@@ -384,12 +461,19 @@ class SemanticEngine:
                         table_ref=table_ref,
                         stage_name="L2 stage_c",
                     )
-                    results[cr.column] = cr
                 except LLMStageError:
+                    self._finalize_attempt(single_attempt, parsed_ok=False)
                     logger.warning(
                         f"Stage C failed for {col_name} "
                         f"in {table_ref}"
                     )
+                    continue
+                self._finalize_attempt(single_attempt, parsed_ok=True)
+                results[cr.column] = cr
+            return results
+        self._finalize_attempt(attempt, parsed_ok=True)
+        for cr in batch_result.columns:
+            results[cr.column] = cr
         return results
 
     def interpret_table_staged(
@@ -417,6 +501,7 @@ class SemanticEngine:
         """Same as `interpret_table_staged` plus per-stage metrics."""
         import time
 
+        self._llm_attempts = []
         metrics = StageMetrics()
         original_invoke = self._llm_client.invoke
 
@@ -447,12 +532,16 @@ class SemanticEngine:
                     "table_ref",
                     f"unity://{table_metadata.get('table_name', 'unknown')}",
                 )
-                raise LLMStageError(
+                raise StageBFailureError(
                     table_ref=table_ref,
                     stage_name="L2 stage_b",
                     step_errors=[("stage_b", ValueError(
                         f"B_FAILED: raw={stage_b.raw_coverage.pct}"
                     ))],
+                    stage_a=stage_a,
+                    stage_b=stage_b,
+                    metrics=metrics,
+                    llm_attempts=self.snapshot_llm_attempts(),
                 )
 
             start = time.monotonic_ns()

--- a/src/sema/engine/semantic_utils.py
+++ b/src/sema/engine/semantic_utils.py
@@ -1,0 +1,43 @@
+"""Helpers for SemanticEngine: LLM-attempt buffer, prompt hashing."""
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+
+
+@dataclass
+class LLMAttempt:
+    """One logical LLMClient.invoke() call recorded for forensics.
+
+    Populated around each invoke (appended before, mutated after) so both
+    successful and failed invocations are captured. Lives on the
+    SemanticEngine instance and dies with it.
+    """
+
+    stage: str
+    batch_index: int | None
+    prompt_text: str
+    prompt_hash: str
+    raw_response: str | None
+    parsed_ok: bool
+
+
+def hash_prompt(prompt: str) -> str:
+    return hashlib.sha256(prompt.encode("utf-8")).hexdigest()
+
+
+def stringify_response(response: object) -> str | None:
+    if response is None:
+        return None
+    content = getattr(response, "content", None)
+    if isinstance(content, str):
+        return content
+    if hasattr(response, "model_dump_json"):
+        try:
+            return str(response.model_dump_json())
+        except Exception:
+            return None
+    try:
+        return str(response)
+    except Exception:
+        return None

--- a/src/sema/engine/stage_utils.py
+++ b/src/sema/engine/stage_utils.py
@@ -65,6 +65,7 @@ _KEY_PATTERN = re.compile(
 )
 
 _RAW_COVERAGE_THRESHOLD = 0.75
+_DEFAULT_PARTIAL_COVERAGE_FLOOR = 0.60
 
 
 # -- Shared formatting helpers ---------------------------------------------
@@ -426,13 +427,26 @@ def determine_b_status(
     raw_coverage: StageBCoverage,
     critical_coverage: StageBCoverage,
     unresolved: list[UnresolvedColumn],
+    metadata_tier: str = "rich",
+    partial_coverage_floor: float = _DEFAULT_PARTIAL_COVERAGE_FLOOR,
 ) -> Literal["B_SUCCESS", "B_PARTIAL", "B_FAILED"]:
-    """Determine Stage B outcome from coverage metrics."""
+    """Determine Stage B outcome from coverage metrics.
+
+    Tier-keyed `B_PARTIAL` admission floor:
+      - `rich` keeps the existing 0.75 floor.
+      - `sparse` / `name_only` lower the floor to `partial_coverage_floor`
+        (default 0.60), reflecting that the LLM had degraded inputs.
+    `B_SUCCESS` and the critical-coverage floor are unchanged.
+    """
     if critical_coverage.total > 0 and critical_coverage.pct < 1.0:
         return "B_FAILED"
     if raw_coverage.pct >= 1.0 and not unresolved:
         return "B_SUCCESS"
-    if raw_coverage.pct >= _RAW_COVERAGE_THRESHOLD:
+    if metadata_tier == "rich":
+        floor = _RAW_COVERAGE_THRESHOLD
+    else:
+        floor = partial_coverage_floor
+    if raw_coverage.pct >= floor:
         return "B_PARTIAL"
     return "B_FAILED"
 

--- a/src/sema/eval/failure_artifact.py
+++ b/src/sema/eval/failure_artifact.py
@@ -1,0 +1,100 @@
+"""Forensic artifact persistence for failed tables.
+
+Writes `{table}__{label}__failure.json` alongside the existing
+`*__telemetry.json` artifacts so post-mortem can be done offline.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from sema.eval.failure_artifact_utils import (
+    counters_for_exc,
+    llm_attempts_for_exc,
+    prompt_hashes_for_exc,
+    stage_a_output_for_exc,
+    step_errors_for_exc,
+    unresolved_columns_for_exc,
+)
+from sema.eval.runner_utils import dump_filename, write_json
+
+
+def classify_failure(exc: BaseException) -> str:
+    from sema.circuit_breaker import CircuitOpenError
+    from sema.llm_client import (
+        LLMStageError,
+        StageBFailureError,
+        _is_rate_limit_error,
+        _is_service_health_failure,
+    )
+
+    if isinstance(exc, CircuitOpenError):
+        return "circuit_open"
+    if isinstance(exc, StageBFailureError):
+        return "semantic_coverage"
+    if isinstance(exc, LLMStageError):
+        if any(_is_service_health_failure(e) for _, e in exc.step_errors):
+            return "service_health"
+        if exc.step_errors and all(
+            _is_rate_limit_error(e) for _, e in exc.step_errors
+        ):
+            return "rate_limit"
+        if not exc.step_errors:
+            return "unknown"
+        return "content_failure"
+    return "unknown"
+
+
+def build_failure_artifact(
+    *,
+    exc: BaseException,
+    table_ref: str,
+    run_id: str,
+    failure_stage: str,
+    metadata_tier: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "table_ref": table_ref,
+        "run_id": run_id,
+        "failure_stage": failure_stage,
+        "failure_classification": classify_failure(exc),
+        "metadata_tier": metadata_tier,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "error_message": str(exc),
+        "step_errors": step_errors_for_exc(exc),
+        "stage_a_output": stage_a_output_for_exc(exc),
+        "unresolved_columns": unresolved_columns_for_exc(exc),
+        "counters": counters_for_exc(exc),
+        "prompt_hashes": prompt_hashes_for_exc(exc),
+        "llm_attempts": llm_attempts_for_exc(exc),
+    }
+
+
+def failure_dump_filename(table_ref: str, label: str) -> str:
+    base = dump_filename(table_ref, label, telemetry=False)
+    return base.removesuffix(".json") + "__failure.json"
+
+
+def dump_table_failure_artifact(
+    *,
+    exc: BaseException,
+    table_ref: str,
+    label: str,
+    output_dir: Path | str | None,
+    run_id: str,
+    failure_stage: str,
+    metadata_tier: str | None = None,
+) -> Path | None:
+    if output_dir is None:
+        return None
+    out_dir = Path(output_dir)
+    artifact = build_failure_artifact(
+        exc=exc,
+        table_ref=table_ref,
+        run_id=run_id,
+        failure_stage=failure_stage,
+        metadata_tier=metadata_tier,
+    )
+    out = out_dir / failure_dump_filename(table_ref, label)
+    return write_json(out, artifact)

--- a/src/sema/eval/failure_artifact_utils.py
+++ b/src/sema/eval/failure_artifact_utils.py
@@ -1,0 +1,110 @@
+"""Helpers that extract artifact fields from a failure exception."""
+from __future__ import annotations
+
+import hashlib
+from dataclasses import asdict, is_dataclass
+from typing import Any
+
+
+def _safe_serialize(value: Any) -> Any:
+    if value is None:
+        return None
+    if hasattr(value, "model_dump"):
+        try:
+            return value.model_dump(mode="json")
+        except Exception:
+            return None
+    if is_dataclass(value) and not isinstance(value, type):
+        try:
+            return asdict(value)
+        except Exception:
+            return None
+    return value
+
+
+def _stage_b_from_exc(exc: BaseException) -> Any:
+    return getattr(exc, "stage_b", None)
+
+
+def _stage_a_from_exc(exc: BaseException) -> Any:
+    return getattr(exc, "stage_a", None)
+
+
+def stage_a_output_for_exc(exc: BaseException) -> Any:
+    return _safe_serialize(_stage_a_from_exc(exc))
+
+
+def unresolved_columns_for_exc(exc: BaseException) -> list[dict[str, Any]]:
+    sb = _stage_b_from_exc(exc)
+    if sb is None or not getattr(sb, "unresolved_columns", None):
+        return []
+    out = []
+    for u in sb.unresolved_columns:
+        ud = _safe_serialize(u)
+        if isinstance(ud, dict):
+            out.append(ud)
+    return out
+
+
+def counters_for_exc(exc: BaseException) -> dict[str, int]:
+    sb = _stage_b_from_exc(exc)
+    if sb is None:
+        return {
+            "batches_attempted": 0,
+            "batches_succeeded": 0,
+            "retries_used": 0,
+            "splits_used": 0,
+            "rescues_used": 0,
+        }
+    batches = list(getattr(sb, "batch_results", []) or [])
+    return {
+        "batches_attempted": len(batches),
+        "batches_succeeded": len(batches),
+        "retries_used": int(getattr(sb, "retries_used", 0) or 0),
+        "splits_used": int(getattr(sb, "splits_used", 0) or 0),
+        "rescues_used": int(getattr(sb, "rescues_used", 0) or 0),
+    }
+
+
+def llm_attempts_for_exc(exc: BaseException) -> list[dict[str, Any]]:
+    attempts = getattr(exc, "llm_attempts", []) or []
+    out = []
+    for a in attempts:
+        d = _safe_serialize(a)
+        if isinstance(d, dict):
+            out.append(d)
+    return out
+
+
+def step_errors_for_exc(exc: BaseException) -> list[dict[str, str]]:
+    step_errors = getattr(exc, "step_errors", []) or []
+    return [
+        {
+            "step_name": name,
+            "exception_type": type(err).__name__,
+            "message": str(err),
+        }
+        for name, err in step_errors
+    ]
+
+
+def _hash_strings(parts: list[str]) -> str:
+    return hashlib.sha256("".join(parts).encode("utf-8")).hexdigest()
+
+
+def prompt_hashes_for_exc(exc: BaseException) -> dict[str, str | None]:
+    by_stage: dict[str, list[str]] = {}
+    for a in getattr(exc, "llm_attempts", []) or []:
+        stage = getattr(a, "stage", None)
+        prompt = getattr(a, "prompt_text", None)
+        if not stage or not prompt:
+            continue
+        by_stage.setdefault(stage, []).append(prompt)
+    return {
+        "stage_a": _hash_strings(by_stage["L2 stage_a"])
+        if "L2 stage_a" in by_stage else None,
+        "stage_b": _hash_strings(by_stage["L2 stage_b"])
+        if "L2 stage_b" in by_stage else None,
+        "stage_c": _hash_strings(by_stage["L2 stage_c"])
+        if "L2 stage_c" in by_stage else None,
+    }

--- a/src/sema/llm_client.py
+++ b/src/sema/llm_client.py
@@ -68,22 +68,61 @@ class SynonymExpansion(BaseModel):
 
 
 class LLMStageError(Exception):
-    """Raised when all LLM fallback steps are exhausted for a call."""
+    """Raised when all LLM fallback steps are exhausted for a call.
+
+    Carries `llm_attempts` (defaults to empty) so the engine can attach
+    its per-table attempt buffer at every raise site. The failure-artifact
+    writer reads attempts directly off the exception, decoupling itself
+    from the engine instance.
+    """
 
     def __init__(
         self,
         table_ref: str,
         stage_name: str,
         step_errors: list[tuple[str, Exception]],
+        llm_attempts: list[Any] | None = None,
     ):
         self.table_ref = table_ref
         self.stage_name = stage_name
         self.step_errors = step_errors
+        self.llm_attempts: list[Any] = list(llm_attempts or [])
         steps = "; ".join(f"{name}: {err}" for name, err in step_errors)
         super().__init__(
             f"LLM failed for {table_ref} at stage '{stage_name}' — "
             f"all fallback steps exhausted: [{steps}]"
         )
+
+
+class StageBFailureError(LLMStageError):
+    """Raised on synthetic Stage B coverage failure.
+
+    Carries the staged context (Stage A result, Stage B result, metrics)
+    needed to populate a complete failure artifact. The fields die with
+    the engine instance otherwise — typing the exception keeps them
+    available to `process_table` after the exception bubbles.
+    """
+
+    def __init__(
+        self,
+        *,
+        table_ref: str,
+        stage_name: str,
+        step_errors: list[tuple[str, Exception]],
+        stage_a: Any,
+        stage_b: Any,
+        metrics: Any,
+        llm_attempts: list[Any] | None = None,
+    ):
+        super().__init__(
+            table_ref=table_ref,
+            stage_name=stage_name,
+            step_errors=step_errors,
+            llm_attempts=llm_attempts,
+        )
+        self.stage_a = stage_a
+        self.stage_b = stage_b
+        self.metrics = metrics
 
 
 TRANSIENT_STATUS_CODES: Final[frozenset[int]] = frozenset({429, 500, 502, 503, 504})
@@ -120,6 +159,40 @@ def _all_step_errors_rate_limited(stage_err: "LLMStageError") -> bool:
     if not stage_err.step_errors:
         return False
     return all(_is_rate_limit_error(err) for _, err in stage_err.step_errors)
+
+
+_SERVICE_HEALTH_STATUS_CODES: Final[frozenset[int]] = frozenset({500, 502, 503, 504})
+
+
+def _is_service_health_failure(exc: Exception) -> bool:
+    """True only for signals the LLM provider itself is degraded.
+
+    Records breaker failure on:
+      - HTTP 5xx (500/502/503/504)
+      - Transport / network errors (ConnectionError, TimeoutError)
+
+    Does NOT record (rate limit, content, semantic, unknown):
+      - HTTP 429 / rate-limit messages
+      - json.JSONDecodeError, pydantic.ValidationError, parser ValueError
+      - Synthetic B_FAILED ValueError (defensive — never reaches invoke today)
+      - Unknown exception types (defensive default; quality budget is the
+        safety net for sustained patterns).
+    """
+    if _is_rate_limit_error(exc):
+        return False
+    status = getattr(exc, "status_code", None) or getattr(exc, "http_status", None)
+    if status is not None:
+        try:
+            return int(status) in _SERVICE_HEALTH_STATUS_CODES
+        except (TypeError, ValueError):
+            return False
+    return isinstance(exc, (ConnectionError, TimeoutError))
+
+
+def _stage_error_has_service_health(stage_err: "LLMStageError") -> bool:
+    return any(
+        _is_service_health_failure(err) for _, err in stage_err.step_errors
+    )
 
 
 def parse_llm_response(raw: str, schema: type[T]) -> T:
@@ -225,8 +298,9 @@ class LLMClient:
                 prompt, schema, table_ref, stage_name, simplified_prompt,
             )
         except LLMStageError as stage_err:
-            if self._circuit_breaker is not None and not _all_step_errors_rate_limited(
-                stage_err,
+            if (
+                self._circuit_breaker is not None
+                and _stage_error_has_service_health(stage_err)
             ):
                 self._circuit_breaker.record_failure()
             self._record_stats(start, prompt, "")
@@ -237,6 +311,15 @@ class LLMClient:
         response_text = self._response_text_for_stats(result)
         self._record_stats(start, prompt, response_text)
         return result
+
+    @property
+    def last_response(self) -> Any:
+        """Read-only view of the most recent raw LLM response.
+
+        Engines use this to capture forensics without changing the
+        invoke() return contract.
+        """
+        return self._last_response
 
     def _response_text_for_stats(self, result: Any) -> str:
         if hasattr(result, "model_dump_json"):

--- a/src/sema/models/config.py
+++ b/src/sema/models/config.py
@@ -117,6 +117,13 @@ class BuildConfig(BaseSettings):
     circuit_breaker_timeout: int = 60
     circuit_breaker_success_threshold: int = 2
 
+    partial_coverage_floor: float = 0.60
+    metadata_rich_column_comment_floor: float = 0.60
+
+    quality_budget_max_failure_rate: float = 0.30
+    quality_budget_max_non_contributing_rate: float = 0.40
+    quality_budget_min_processed: int = 5
+
     databricks: DatabricksConfig = Field(default_factory=DatabricksConfig)
     neo4j: Neo4jConfig = Field(default_factory=Neo4jConfig)
     llm: LLMConfig = Field(default_factory=LLMConfig)

--- a/src/sema/pipeline/build.py
+++ b/src/sema/pipeline/build.py
@@ -60,6 +60,9 @@ class TableResult:
 
     skip_reason: str | None = None
 
+    partial: bool = False
+    metadata_tier: str | None = None
+
     @classmethod
     def success(
         cls,
@@ -67,6 +70,8 @@ class TableResult:
         entities: int = 0,
         properties: int = 0,
         terms: int = 0,
+        partial: bool = False,
+        metadata_tier: str | None = None,
     ) -> TableResult:
         return cls(
             table_ref=table_ref,
@@ -74,17 +79,21 @@ class TableResult:
             entities_created=entities,
             properties_created=properties,
             terms_created=terms,
+            partial=partial,
+            metadata_tier=metadata_tier,
         )
 
     @classmethod
     def failed(
-        cls, table_ref: str, stage: str, error: str
+        cls, table_ref: str, stage: str, error: str,
+        metadata_tier: str | None = None,
     ) -> TableResult:
         return cls(
             table_ref=table_ref,
             status="failed",
             failed_stage=stage,
             error_message=error,
+            metadata_tier=metadata_tier,
         )
 
     @classmethod
@@ -150,7 +159,9 @@ def _try_resume(
     stored_dicts = loader.load_assertions(work_item.fqn)
     stored_assertions = _reconstruct_assertions(stored_dicts)
     from sema.graph.materializer import materialize_unified
-    materialize_unified(loader, stored_assertions)
+    materialize_unified(
+        loader, stored_assertions, source_schema=work_item.schema,
+    )
     return TableResult.skipped(work_item.fqn, "resume: assertions exist")
 
 
@@ -167,6 +178,8 @@ def process_table(
     prompt_layers: Any = None,
     eval_dump_dir: str | None = None,
     eval_config_label: str = "run",
+    partial_coverage_floor: float = 0.60,
+    metadata_rich_column_comment_floor: float = 0.60,
 ) -> TableResult:
     """Process a single table through all pipeline stages."""
     if resume:
@@ -181,19 +194,51 @@ def process_table(
             vocab_workers=vocab_workers,
             domain_context=domain_context,
             prompt_layers=prompt_layers,
+            eval_dump_dir=eval_dump_dir,
+            partial_coverage_floor=partial_coverage_floor,
+            metadata_rich_column_comment_floor=(
+                metadata_rich_column_comment_floor
+            ),
         )
         if isinstance(result, TableResult):
             return result
         all_assertions, staged_output = result
     except CircuitOpenError as e:
         logger.warning(f"Table {work_item.fqn} skipped (circuit open): {e}")
-        return TableResult.failed(work_item.fqn, "circuit_breaker", str(e))
+        tier = getattr(e, "metadata_tier", None)
+        _write_failure_artifact(
+            e, work_item.fqn, "circuit_breaker",
+            eval_dump_dir, eval_config_label, run_id,
+            metadata_tier=tier,
+        )
+        return TableResult.failed(
+            work_item.fqn, "circuit_breaker", str(e),
+            metadata_tier=tier,
+        )
     except LLMStageError as e:
         logger.warning(f"Table {work_item.fqn} failed: {e}")
-        return TableResult.failed(work_item.fqn, e.stage_name, str(e))
+        tier = getattr(e, "metadata_tier", None)
+        _write_failure_artifact(
+            e, work_item.fqn, e.stage_name,
+            eval_dump_dir, eval_config_label, run_id,
+            metadata_tier=tier,
+        )
+        return TableResult.failed(
+            work_item.fqn, e.stage_name, str(e),
+            metadata_tier=tier,
+        )
     except Exception as e:
         logger.warning(f"Table {work_item.fqn} failed: {e}")
-        return TableResult.failed(work_item.fqn, "unknown", str(e))
+        tier = getattr(e, "metadata_tier", None)
+        _write_failure_artifact(
+            e, work_item.fqn, "unknown",
+            eval_dump_dir, eval_config_label, run_id,
+            metadata_tier=tier,
+        )
+        return TableResult.failed(
+            work_item.fqn, "unknown", str(e),
+            metadata_tier=tier,
+        )
 
     if eval_dump_dir:
         _dump_for_eval(
@@ -202,12 +247,57 @@ def process_table(
         )
 
     entity_count, prop_count, term_count = _count_results(all_assertions)
+    tier = getattr(staged_output, "metadata_tier", None)
+    is_partial = bool(
+        getattr(staged_output, "stage_b", None)
+        and getattr(staged_output.stage_b, "status", None) == "B_PARTIAL"
+    )
+    if is_partial and tier is not None:
+        raw_pct = getattr(
+            staged_output.stage_b.raw_coverage, "pct", 0.0,
+        )
+        logger.warning(
+            f"partial commit: table_ref={work_item.fqn} "
+            f"tier={tier} raw_coverage={raw_pct:.4f}"
+        )
     return TableResult.success(
         work_item.fqn,
         entities=entity_count,
         properties=prop_count,
         terms=term_count,
+        partial=is_partial,
+        metadata_tier=tier,
     )
+
+
+def _write_failure_artifact(
+    exc: BaseException,
+    table_ref: str,
+    failure_stage: str,
+    eval_dump_dir: str | None,
+    label: str,
+    run_id: str,
+    metadata_tier: str | None = None,
+) -> None:
+    """Best-effort failure artifact write — never raises."""
+    if not eval_dump_dir:
+        return
+    try:
+        from sema.eval.failure_artifact import dump_table_failure_artifact
+
+        dump_table_failure_artifact(
+            exc=exc,
+            table_ref=table_ref,
+            label=label,
+            output_dir=eval_dump_dir,
+            run_id=run_id,
+            failure_stage=failure_stage,
+            metadata_tier=metadata_tier,
+        )
+    except Exception as e:
+        logger.warning(
+            f"Failure-artifact write failed for {table_ref}: {e}"
+        )
 
 
 def _dump_for_eval(
@@ -251,17 +341,26 @@ def aggregate_report(
     """Aggregate TableResult list into a build report."""
     report: dict[str, Any] = {
         "tables_processed": 0,
+        "tables_succeeded_full": 0,
+        "tables_succeeded_partial": 0,
         "entities_created": 0,
         "properties_created": 0,
         "terms_created": 0,
         "tables_failed": 0,
         "tables_skipped": 0,
         "failed_tables": [],
+        "metadata_tier_counts": {"rich": 0, "sparse": 0, "name_only": 0},
     }
 
     for r in results:
+        if r.metadata_tier in report["metadata_tier_counts"]:
+            report["metadata_tier_counts"][r.metadata_tier] += 1
         if r.status == "success":
             report["tables_processed"] += 1
+            if r.partial:
+                report["tables_succeeded_partial"] += 1
+            else:
+                report["tables_succeeded_full"] += 1
             report["entities_created"] += r.entities_created
             report["properties_created"] += r.properties_created
             report["terms_created"] += r.terms_created
@@ -271,6 +370,7 @@ def aggregate_report(
                 "table": r.table_ref,
                 "stage": r.failed_stage,
                 "error": r.error_message,
+                "metadata_tier": r.metadata_tier,
             })
         elif r.status == "skipped":
             report["tables_skipped"] += 1

--- a/src/sema/pipeline/build_utils.py
+++ b/src/sema/pipeline/build_utils.py
@@ -110,7 +110,9 @@ def _run_extraction(
 class _StagedOutput:
     """Carries staged intermediates for enriched vocab context."""
 
-    __slots__ = ("stage_a", "stage_b", "status", "telemetry")
+    __slots__ = (
+        "stage_a", "stage_b", "status", "telemetry", "metadata_tier",
+    )
 
     def __init__(
         self,
@@ -118,11 +120,13 @@ class _StagedOutput:
         stage_b: StageBResult,
         status: StageStatus,
         telemetry: Any = None,
+        metadata_tier: str | None = None,
     ) -> None:
         self.stage_a = stage_a
         self.stage_b = stage_b
         self.status = status
         self.telemetry = telemetry
+        self.metadata_tier = metadata_tier
 
 
 def _run_semantic_interpretation(
@@ -133,6 +137,9 @@ def _run_semantic_interpretation(
     column_batch_size: int,
     domain_context: DomainContext | None = None,
     prompt_layers: Any = None,
+    capture_llm_attempts: bool = False,
+    metadata_tier: str = "rich",
+    partial_coverage_floor: float = 0.60,
 ) -> tuple[list[Assertion], _StagedOutput]:
     from sema.engine.semantic import SemanticEngine
 
@@ -147,6 +154,9 @@ def _run_semantic_interpretation(
         column_batch_size=column_batch_size,
         domain_context=domain_context,
         prompt_layers=prompt_layers,
+        capture_llm_attempts=capture_llm_attempts,
+        metadata_tier=metadata_tier,
+        partial_coverage_floor=partial_coverage_floor,
     )
 
     assertions, stage_a, stage_b, c_results, metrics = (
@@ -174,7 +184,8 @@ def _run_semantic_interpretation(
         f"coverage: {tel.raw_coverage_pct:.0%})"
     )
     return assertions, _StagedOutput(
-        stage_a, stage_b, status, telemetry=tel,
+        stage_a, stage_b, status,
+        telemetry=tel, metadata_tier=metadata_tier,
     )
 
 
@@ -467,6 +478,9 @@ def _run_pipeline_stages(
     vocab_workers: int = 8,
     domain_context: DomainContext | None = None,
     prompt_layers: Any = None,
+    eval_dump_dir: str | None = None,
+    partial_coverage_floor: float = 0.60,
+    metadata_rich_column_comment_floor: float = 0.60,
 ) -> tuple[list[Assertion], _StagedOutput] | Any:
     """Run all pipeline stages for a single table.
 
@@ -490,12 +504,28 @@ def _run_pipeline_stages(
             work_item.fqn, "no table metadata"
         )
 
-    semantic_assertions, staged_output = _run_semantic_interpretation(
-        table_meta, work_item, llm_client, run_id,
-        column_batch_size,
-        domain_context=domain_context,
-        prompt_layers=prompt_layers,
+    from sema.engine.metadata_tier import classify_metadata_tier
+    tier = classify_metadata_tier(
+        table_meta,
+        rich_floor=metadata_rich_column_comment_floor,
     )
+
+    try:
+        semantic_assertions, staged_output = _run_semantic_interpretation(
+            table_meta, work_item, llm_client, run_id,
+            column_batch_size,
+            domain_context=domain_context,
+            prompt_layers=prompt_layers,
+            capture_llm_attempts=bool(eval_dump_dir),
+            metadata_tier=tier,
+            partial_coverage_floor=partial_coverage_floor,
+        )
+    except BaseException as exc:
+        try:
+            exc.metadata_tier = tier  # type: ignore[attr-defined]
+        except (AttributeError, TypeError):
+            pass
+        raise
     all_assertions.extend(semantic_assertions)
 
     vocab_assertions = _run_vocabulary_alignment(

--- a/src/sema/pipeline/orchestrate.py
+++ b/src/sema/pipeline/orchestrate.py
@@ -62,8 +62,9 @@ def run_build(config: BuildConfig) -> dict[str, Any]:
         driver.close()
         return aggregate_report([])
 
-    for schema in sorted({wi.schema for wi in work_items}):
-        loader.delete_study_scoped(schema)
+    if not config.resume:
+        for schema in sorted({wi.schema for wi in work_items}):
+            loader.delete_study_scoped(schema)
 
     circuit_breaker = CircuitBreaker(
         failure_threshold=config.circuit_breaker_threshold,
@@ -109,6 +110,13 @@ def run_build(config: BuildConfig) -> dict[str, Any]:
         loader, run_id,
         domain_context=domain_context,
     )
+
+    from sema.pipeline.quality_budget import enforce_quality_budget
+    try:
+        enforce_quality_budget(results, config)
+    except Exception:
+        driver.close()
+        raise
 
     report = _collect_results(results)
 

--- a/src/sema/pipeline/orchestrate_utils.py
+++ b/src/sema/pipeline/orchestrate_utils.py
@@ -129,6 +129,10 @@ def _spawn_workers_parallel(
             prompt_layers=layers,
             eval_dump_dir=config.eval_dump_dir,
             eval_config_label=config.eval_config_label,
+            partial_coverage_floor=config.partial_coverage_floor,
+            metadata_rich_column_comment_floor=(
+                config.metadata_rich_column_comment_floor
+            ),
         )
 
     with ThreadPoolExecutor(
@@ -198,6 +202,10 @@ def _spawn_workers(
             prompt_layers=layers,
             eval_dump_dir=config.eval_dump_dir,
             eval_config_label=config.eval_config_label,
+            partial_coverage_floor=config.partial_coverage_floor,
+            metadata_rich_column_comment_floor=(
+                config.metadata_rich_column_comment_floor
+            ),
         )
         _log_result(result, f"    ", config.verbose)
         results.append(result)

--- a/src/sema/pipeline/quality_budget.py
+++ b/src/sema/pipeline/quality_budget.py
@@ -1,0 +1,132 @@
+"""Run-level quality budget with two triggers, one exception.
+
+Stateless check post-`_collect_results`, pre-`run_fk_detection`.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from typing import Any, Literal
+
+from sema.models.config import BuildConfig
+from sema.pipeline.build import TableResult
+
+
+_STAGE_B_LABEL = "L2 stage_b"
+_STAGE_A_LABEL = "L2 stage_a"
+_CIRCUIT_LABEL = "circuit_breaker"
+_RESUME_PREFIX = "resume:"
+
+
+@dataclass
+class Breakdown:
+    succeeded: int = 0
+    stage_b_failed: int = 0
+    circuit_open: int = 0
+    stage_a_failed: int = 0
+    other_failed: int = 0
+    skipped_resume: int = 0
+    skipped_other: int = 0
+
+    @property
+    def all_failed(self) -> int:
+        return (
+            self.stage_b_failed + self.circuit_open
+            + self.stage_a_failed + self.other_failed
+        )
+
+
+class QualityBudgetExceeded(Exception):
+    def __init__(
+        self,
+        *,
+        trigger: Literal["stage_b_failure_rate", "run_non_contributing_rate"],
+        failure_rate: float,
+        threshold: float,
+        denominator: int,
+        breakdown: Breakdown,
+    ):
+        self.trigger = trigger
+        self.failure_rate = failure_rate
+        self.threshold = threshold
+        self.denominator = denominator
+        self.breakdown = asdict(breakdown)
+        super().__init__(
+            f"Quality budget exceeded ({trigger}): rate={failure_rate:.3f}, "
+            f"threshold={threshold:.3f}, denominator={denominator}, "
+            f"breakdown={self.breakdown}"
+        )
+
+
+def compute_breakdown(results: list[TableResult]) -> Breakdown:
+    b = Breakdown()
+    for r in results:
+        if r.status == "success":
+            b.succeeded += 1
+        elif r.status == "failed":
+            stage = r.failed_stage or ""
+            if stage == _STAGE_B_LABEL:
+                b.stage_b_failed += 1
+            elif stage == _STAGE_A_LABEL:
+                b.stage_a_failed += 1
+            elif stage == _CIRCUIT_LABEL:
+                b.circuit_open += 1
+            else:
+                b.other_failed += 1
+        elif r.status == "skipped":
+            reason = r.skip_reason or ""
+            if reason.startswith(_RESUME_PREFIX):
+                b.skipped_resume += 1
+            else:
+                b.skipped_other += 1
+    return b
+
+
+def _check_stage_b_trigger(
+    b: Breakdown, config: BuildConfig,
+) -> None:
+    graph_contributing = (
+        b.succeeded + b.stage_b_failed + b.skipped_resume
+    )
+    if graph_contributing < config.quality_budget_min_processed:
+        return
+    rate = b.stage_b_failed / graph_contributing
+    if rate > config.quality_budget_max_failure_rate:
+        raise QualityBudgetExceeded(
+            trigger="stage_b_failure_rate",
+            failure_rate=rate,
+            threshold=config.quality_budget_max_failure_rate,
+            denominator=graph_contributing,
+            breakdown=b,
+        )
+
+
+def _check_run_reliability_trigger(
+    b: Breakdown, config: BuildConfig,
+) -> None:
+    attempted = b.succeeded + b.all_failed + b.skipped_other
+    if attempted < config.quality_budget_min_processed:
+        return
+    non_contributing = (
+        b.stage_a_failed + b.circuit_open + b.other_failed
+    )
+    rate = non_contributing / attempted
+    if rate > config.quality_budget_max_non_contributing_rate:
+        raise QualityBudgetExceeded(
+            trigger="run_non_contributing_rate",
+            failure_rate=rate,
+            threshold=config.quality_budget_max_non_contributing_rate,
+            denominator=attempted,
+            breakdown=b,
+        )
+
+
+def enforce_quality_budget(
+    results: list[TableResult], config: BuildConfig,
+) -> None:
+    """Raise QualityBudgetExceeded when either trigger fires.
+
+    Stable ordering: Stage B graph-health is checked first.
+    """
+    b = compute_breakdown(results)
+    _check_stage_b_trigger(b, config)
+    _check_run_reliability_trigger(b, config)

--- a/tests/unit/test_aggregate_report_tiers.py
+++ b/tests/unit/test_aggregate_report_tiers.py
@@ -1,0 +1,57 @@
+"""aggregate_report distinguishes succeeded full vs partial; per-tier counts."""
+from __future__ import annotations
+
+import pytest
+
+from sema.pipeline.build import TableResult, aggregate_report
+
+pytestmark = pytest.mark.unit
+
+
+class TestAggregateReportFullPartial:
+    def test_distinguishes_full_and_partial(self):
+        results = [
+            TableResult.success(
+                "t1", entities=1, properties=1,
+                partial=False, metadata_tier="rich",
+            ),
+            TableResult.success(
+                "t2", entities=1, properties=1,
+                partial=True, metadata_tier="name_only",
+            ),
+            TableResult.success(
+                "t3", entities=1, properties=1,
+                partial=True, metadata_tier="sparse",
+            ),
+        ]
+        report = aggregate_report(results)
+        assert report["tables_processed"] == 3
+        assert report["tables_succeeded_full"] == 1
+        assert report["tables_succeeded_partial"] == 2
+
+    def test_metadata_tier_counts(self):
+        results = [
+            TableResult.success("t1", metadata_tier="rich"),
+            TableResult.success("t2", metadata_tier="rich"),
+            TableResult.success("t3", metadata_tier="sparse"),
+            TableResult.failed("t4", "L2 stage_b", "fail",
+                               metadata_tier="name_only"),
+        ]
+        report = aggregate_report(results)
+        assert report["metadata_tier_counts"] == {
+            "rich": 2, "sparse": 1, "name_only": 1,
+        }
+
+
+class TestPartialCountsAsSucceededForBudget:
+    """B_PARTIAL outcomes count as 'succeeded' for graph-health budget.
+    The aggregated report's `tables_processed` includes partials so the
+    Stage B budget denominator/numerator semantics are consistent."""
+
+    def test_partial_counts_in_processed(self):
+        results = [
+            TableResult.success("t1", partial=True, metadata_tier="sparse"),
+        ]
+        report = aggregate_report(results)
+        assert report["tables_processed"] == 1
+        assert report["tables_failed"] == 0

--- a/tests/unit/test_cli_quality_budget.py
+++ b/tests/unit/test_cli_quality_budget.py
@@ -1,0 +1,112 @@
+"""--no-quality-budget CLI flag (Section 6)."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def captured_config_holder():
+    return {}
+
+
+def _patch_run_build_capture(captured: dict, side_effect=None):
+    def fake(cfg):
+        captured["config"] = cfg
+        if side_effect is not None:
+            raise side_effect
+        return {"tables_processed": 0, "failed_tables": []}
+    return fake
+
+
+class TestNoQualityBudgetFlag:
+    def test_flag_sets_both_ceilings_to_one(
+        self, captured_config_holder,
+    ):
+        from sema.cli import cli
+
+        runner = CliRunner()
+        with patch(
+            "sema.cli.run_build",
+            side_effect=_patch_run_build_capture(captured_config_holder),
+        ):
+            result = runner.invoke(cli, [
+                "build", "--no-quality-budget", "--skip-embeddings",
+            ])
+
+        assert result.exit_code == 0, result.output
+        cfg = captured_config_holder["config"]
+        assert cfg.quality_budget_max_failure_rate == 1.0
+        assert cfg.quality_budget_max_non_contributing_rate == 1.0
+
+    def test_default_keeps_strict_thresholds(
+        self, captured_config_holder,
+    ):
+        from sema.cli import cli
+
+        runner = CliRunner()
+        with patch(
+            "sema.cli.run_build",
+            side_effect=_patch_run_build_capture(captured_config_holder),
+        ):
+            result = runner.invoke(cli, [
+                "build", "--skip-embeddings",
+            ])
+
+        assert result.exit_code == 0, result.output
+        cfg = captured_config_holder["config"]
+        assert cfg.quality_budget_max_failure_rate == 0.30
+        assert cfg.quality_budget_max_non_contributing_rate == 0.40
+
+
+class TestExitCodeOnBudgetExceeded:
+    def test_exit_code_seven_on_quality_budget_exception(
+        self, captured_config_holder,
+    ):
+        from sema.cli import cli
+        from sema.pipeline.quality_budget import (
+            Breakdown, QualityBudgetExceeded,
+        )
+
+        err = QualityBudgetExceeded(
+            trigger="stage_b_failure_rate",
+            failure_rate=0.40,
+            threshold=0.30,
+            denominator=10,
+            breakdown=Breakdown(succeeded=6, stage_b_failed=4),
+        )
+        runner = CliRunner()
+        with patch(
+            "sema.cli.run_build",
+            side_effect=_patch_run_build_capture(
+                captured_config_holder, side_effect=err,
+            ),
+        ):
+            result = runner.invoke(cli, [
+                "build", "--skip-embeddings",
+            ])
+
+        assert result.exit_code == 7
+
+    def test_exit_code_one_on_other_exception(
+        self, captured_config_holder,
+    ):
+        from sema.cli import cli
+
+        runner = CliRunner()
+        with patch(
+            "sema.cli.run_build",
+            side_effect=_patch_run_build_capture(
+                captured_config_holder,
+                side_effect=RuntimeError("oops"),
+            ),
+        ):
+            result = runner.invoke(cli, [
+                "build", "--skip-embeddings",
+            ])
+
+        assert result.exit_code == 1

--- a/tests/unit/test_determine_b_status_tiered.py
+++ b/tests/unit/test_determine_b_status_tiered.py
@@ -1,0 +1,145 @@
+"""Tier-keyed B_PARTIAL admission floor (Section 5b)."""
+from __future__ import annotations
+
+import pytest
+
+from sema.engine.stage_utils import determine_b_status
+from sema.models.stages import StageBCoverage, UnresolvedColumn
+
+pytestmark = pytest.mark.unit
+
+
+def _cov(pct: float, classified: int = None, total: int = 10) -> StageBCoverage:
+    if classified is None:
+        classified = int(round(pct * total))
+    return StageBCoverage(classified=classified, total=total, pct=pct)
+
+
+class TestBSuccessPreservedAcrossTiers:
+    def test_rich_b_success_unchanged(self):
+        st = determine_b_status(
+            raw_coverage=_cov(1.0),
+            critical_coverage=_cov(1.0),
+            unresolved=[],
+            metadata_tier="rich",
+        )
+        assert st == "B_SUCCESS"
+
+    def test_name_only_b_success_unchanged(self):
+        st = determine_b_status(
+            raw_coverage=_cov(1.0),
+            critical_coverage=_cov(1.0),
+            unresolved=[],
+            metadata_tier="name_only",
+        )
+        assert st == "B_SUCCESS"
+
+
+class TestRichFloorPreserved:
+    def test_rich_at_0_85_with_unresolved_partial(self):
+        st = determine_b_status(
+            raw_coverage=_cov(0.85),
+            critical_coverage=_cov(1.0),
+            unresolved=[
+                UnresolvedColumn(
+                    column="x", reason="execution_failure", tier="peripheral",
+                ),
+                UnresolvedColumn(
+                    column="y", reason="execution_failure", tier="peripheral",
+                ),
+            ],
+            metadata_tier="rich",
+        )
+        assert st == "B_PARTIAL"
+
+    def test_rich_at_0_65_b_failed(self):
+        st = determine_b_status(
+            raw_coverage=_cov(0.65),
+            critical_coverage=_cov(1.0),
+            unresolved=[],
+            metadata_tier="rich",
+        )
+        assert st == "B_FAILED"
+
+
+class TestSparseAndNameOnlyLoweredFloor:
+    def test_sparse_at_0_65_partial(self):
+        st = determine_b_status(
+            raw_coverage=_cov(0.65),
+            critical_coverage=_cov(1.0),
+            unresolved=[],
+            metadata_tier="sparse",
+        )
+        assert st == "B_PARTIAL"
+
+    def test_name_only_at_0_62_partial(self):
+        st = determine_b_status(
+            raw_coverage=_cov(0.62),
+            critical_coverage=_cov(1.0),
+            unresolved=[],
+            metadata_tier="name_only",
+        )
+        assert st == "B_PARTIAL"
+
+    def test_name_only_below_floor_b_failed(self):
+        st = determine_b_status(
+            raw_coverage=_cov(0.55),
+            critical_coverage=_cov(1.0),
+            unresolved=[],
+            metadata_tier="name_only",
+        )
+        assert st == "B_FAILED"
+
+
+class TestCriticalFloorUnchanged:
+    def test_name_only_with_crit_below_1_b_failed(self):
+        st = determine_b_status(
+            raw_coverage=_cov(0.62),
+            critical_coverage=_cov(0.90),
+            unresolved=[],
+            metadata_tier="name_only",
+        )
+        assert st == "B_FAILED"
+
+
+class TestConfigurableFloor:
+    def test_partial_floor_bumped_reclassifies_sparse(self):
+        st = determine_b_status(
+            raw_coverage=_cov(0.65),
+            critical_coverage=_cov(1.0),
+            unresolved=[],
+            metadata_tier="sparse",
+            partial_coverage_floor=0.70,
+        )
+        assert st == "B_FAILED"
+
+    def test_partial_floor_bumped_does_not_change_rich(self):
+        # Rich still uses its built-in 0.75 floor regardless of param
+        st = determine_b_status(
+            raw_coverage=_cov(0.85),
+            critical_coverage=_cov(1.0),
+            unresolved=[
+                UnresolvedColumn(
+                    column="x", reason="execution_failure", tier="peripheral",
+                ),
+            ],
+            metadata_tier="rich",
+            partial_coverage_floor=0.30,
+        )
+        assert st == "B_PARTIAL"
+
+
+class TestBackwardsCompatibility:
+    """Existing call sites pass no metadata_tier — must still work."""
+
+    def test_omitting_tier_uses_legacy_rich_floor(self):
+        st = determine_b_status(
+            raw_coverage=_cov(0.85),
+            critical_coverage=_cov(1.0),
+            unresolved=[
+                UnresolvedColumn(
+                    column="x", reason="execution_failure", tier="peripheral",
+                ),
+            ],
+        )
+        assert st == "B_PARTIAL"

--- a/tests/unit/test_failure_artifact.py
+++ b/tests/unit/test_failure_artifact.py
@@ -1,0 +1,416 @@
+"""Failed-table forensic artifact (Section 5)."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from sema.engine.semantic import StageMetrics
+from sema.engine.semantic_utils import LLMAttempt
+from sema.llm_client import LLMStageError, StageBFailureError
+from sema.circuit_breaker import CircuitOpenError
+from sema.models.stages import (
+    StageAResult,
+    StageBBatchResult,
+    StageBColumnResult,
+    StageBCoverage,
+    StageBResult,
+    UnresolvedColumn,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _cov(pct: float, classified: int = None, total: int = 10) -> StageBCoverage:
+    if classified is None:
+        classified = int(round(pct * total))
+    return StageBCoverage(classified=classified, total=total, pct=pct)
+
+
+def _stage_a() -> StageAResult:
+    return StageAResult(
+        primary_entity="Patient",
+        grain_hypothesis="one row per patient",
+        confidence=0.9,
+    )
+
+
+def _stage_b_failed() -> StageBResult:
+    return StageBResult(
+        status="B_FAILED",
+        batch_results=[StageBBatchResult(columns=[
+            StageBColumnResult(
+                column="patient_id",
+                canonical_property_label="id",
+                semantic_type="identifier",
+                entity_role="primary_key",
+                needs_stage_c=False,
+            ),
+        ])],
+        raw_coverage=_cov(0.5),
+        critical_coverage=_cov(1.0),
+        unresolved_columns=[
+            UnresolvedColumn(
+                column="age", reason="execution_failure", tier="peripheral",
+            ),
+        ],
+        retries_used=1,
+        splits_used=0,
+        rescues_used=0,
+    )
+
+
+class TestClassifyFailure:
+    def test_circuit_open_classified(self):
+        from sema.eval.failure_artifact import classify_failure
+
+        assert classify_failure(CircuitOpenError("open")) == "circuit_open"
+
+    def test_stage_b_failure_classified_as_semantic_coverage(self):
+        from sema.eval.failure_artifact import classify_failure
+
+        err = StageBFailureError(
+            table_ref="r", stage_name="L2 stage_b",
+            step_errors=[("stage_b", ValueError("B_FAILED"))],
+            stage_a=_stage_a(), stage_b=_stage_b_failed(),
+            metrics=StageMetrics(), llm_attempts=[],
+        )
+        assert classify_failure(err) == "semantic_coverage"
+
+    def test_503_step_classified_as_service_health(self):
+        from sema.eval.failure_artifact import classify_failure
+
+        e503 = Exception("Service Unavailable")
+        e503.status_code = 503
+        err = LLMStageError(
+            table_ref="r", stage_name="L2 stage_a",
+            step_errors=[("structured_output", e503)],
+        )
+        assert classify_failure(err) == "service_health"
+
+    def test_429_only_classified_as_rate_limit(self):
+        from sema.eval.failure_artifact import classify_failure
+
+        e = Exception("rate limit")
+        e.status_code = 429
+        err = LLMStageError(
+            table_ref="r", stage_name="L2 stage_a",
+            step_errors=[("structured_output", e)],
+        )
+        assert classify_failure(err) == "rate_limit"
+
+    def test_json_decode_classified_as_content_failure(self):
+        from sema.eval.failure_artifact import classify_failure
+
+        err = LLMStageError(
+            table_ref="r", stage_name="L2 stage_a",
+            step_errors=[
+                ("plain_invoke", json.JSONDecodeError("bad", "", 0)),
+            ],
+        )
+        assert classify_failure(err) == "content_failure"
+
+    def test_value_error_classified_as_content_failure(self):
+        from sema.eval.failure_artifact import classify_failure
+
+        err = LLMStageError(
+            table_ref="r", stage_name="L2 stage_a",
+            step_errors=[
+                ("plain_invoke", ValueError("Could not parse ...")),
+            ],
+        )
+        assert classify_failure(err) == "content_failure"
+
+    def test_unknown_exception_classified_as_unknown(self):
+        from sema.eval.failure_artifact import classify_failure
+
+        assert classify_failure(RuntimeError("mystery")) == "unknown"
+
+
+class TestBuildFailureArtifact:
+    def test_b_failed_artifact_includes_staged_context(self, tmp_path):
+        from sema.eval.failure_artifact import build_failure_artifact
+
+        att = LLMAttempt(
+            stage="L2 stage_b", batch_index=0,
+            prompt_text="prompt", prompt_hash="hash",
+            raw_response="raw", parsed_ok=False,
+        )
+        err = StageBFailureError(
+            table_ref="unity://cdm.clinical.patient",
+            stage_name="L2 stage_b",
+            step_errors=[("stage_b", ValueError("B_FAILED: raw=0.5"))],
+            stage_a=_stage_a(), stage_b=_stage_b_failed(),
+            metrics=StageMetrics(stage_a_latency_ms=10),
+            llm_attempts=[att],
+        )
+
+        artifact = build_failure_artifact(
+            exc=err,
+            table_ref="unity://cdm.clinical.patient",
+            run_id="run-1",
+            failure_stage="L2 stage_b",
+        )
+
+        assert artifact["table_ref"] == "unity://cdm.clinical.patient"
+        assert artifact["run_id"] == "run-1"
+        assert artifact["failure_stage"] == "L2 stage_b"
+        assert artifact["failure_classification"] == "semantic_coverage"
+        assert artifact["stage_a_output"] is not None
+        assert artifact["stage_a_output"]["primary_entity"] == "Patient"
+        assert len(artifact["unresolved_columns"]) == 1
+        assert artifact["unresolved_columns"][0]["column"] == "age"
+        assert artifact["counters"]["retries_used"] == 1
+        assert artifact["counters"]["batches_attempted"] >= 0
+        assert "stage_b" in artifact["prompt_hashes"]
+        assert artifact["prompt_hashes"]["stage_b"]
+        assert len(artifact["llm_attempts"]) == 1
+        assert artifact["llm_attempts"][0]["parsed_ok"] is False
+        assert len(artifact["step_errors"]) == 1
+        assert artifact["step_errors"][0]["step_name"] == "stage_b"
+
+    def test_stage_a_failure_has_null_stage_a_output(self):
+        from sema.eval.failure_artifact import build_failure_artifact
+
+        att = LLMAttempt(
+            stage="L2 stage_a", batch_index=None,
+            prompt_text="prompt", prompt_hash="hash",
+            raw_response=None, parsed_ok=False,
+        )
+        err = LLMStageError(
+            table_ref="r", stage_name="L2 stage_a",
+            step_errors=[
+                ("structured_output", ValueError("bad")),
+            ],
+            llm_attempts=[att],
+        )
+
+        artifact = build_failure_artifact(
+            exc=err,
+            table_ref="unity://cdm.clinical.patient",
+            run_id="run-1",
+            failure_stage="L2 stage_a",
+        )
+
+        assert artifact["stage_a_output"] is None
+        assert artifact["unresolved_columns"] == []
+        assert artifact["counters"]["batches_attempted"] == 0
+        assert len(artifact["llm_attempts"]) == 1
+        assert artifact["failure_classification"] == "content_failure"
+
+    def test_circuit_open_artifact(self):
+        from sema.eval.failure_artifact import build_failure_artifact
+
+        artifact = build_failure_artifact(
+            exc=CircuitOpenError("circuit open"),
+            table_ref="unity://cdm.clinical.patient",
+            run_id="run-1",
+            failure_stage="circuit_breaker",
+        )
+
+        assert artifact["failure_stage"] == "circuit_breaker"
+        assert artifact["failure_classification"] == "circuit_open"
+        assert artifact["llm_attempts"] == []
+        assert artifact["stage_a_output"] is None
+
+
+class TestDumpTableFailureArtifact:
+    def test_writes_failure_json(self, tmp_path):
+        from sema.eval.failure_artifact import dump_table_failure_artifact
+
+        err = LLMStageError(
+            table_ref="r", stage_name="L2 stage_a",
+            step_errors=[("structured_output", ValueError("bad"))],
+            llm_attempts=[],
+        )
+        path = dump_table_failure_artifact(
+            exc=err,
+            table_ref="unity://cat/sch/patient",
+            label="run",
+            output_dir=tmp_path,
+            run_id="run-1",
+            failure_stage="L2 stage_a",
+        )
+        assert path is not None
+        assert path.exists()
+        assert path.name == "patient__run__failure.json"
+        data = json.loads(path.read_text())
+        assert data["failure_stage"] == "L2 stage_a"
+        assert data["failure_classification"] == "content_failure"
+
+    def test_returns_none_when_output_dir_is_none(self):
+        from sema.eval.failure_artifact import dump_table_failure_artifact
+
+        err = LLMStageError(
+            table_ref="r", stage_name="L2 stage_a",
+            step_errors=[], llm_attempts=[],
+        )
+        path = dump_table_failure_artifact(
+            exc=err,
+            table_ref="unity://cdm.clinical.patient",
+            label="run",
+            output_dir=None,
+            run_id="run-1",
+            failure_stage="L2 stage_a",
+        )
+        assert path is None
+
+
+class TestProcessTableWritesFailureArtifact:
+    def test_b_failed_writes_artifact(self, tmp_path):
+        """End-to-end: process_table with eval_dump_dir set writes
+        *__failure.json on B_FAILED."""
+        from sema.connectors.databricks import TableWorkItem
+        from sema.pipeline.build import process_table
+
+        loader = MagicMock()
+        loader.has_assertions.return_value = False
+        connector = MagicMock()
+        llm_client = MagicMock()
+
+        wi = TableWorkItem(
+            catalog="cat", schema="sch",
+            table_name="patient",
+            fqn="databricks://ws/cat/sch/patient",
+        )
+
+        att = LLMAttempt(
+            stage="L2 stage_b", batch_index=0,
+            prompt_text="prompt", prompt_hash="h",
+            raw_response="raw", parsed_ok=False,
+        )
+        err = StageBFailureError(
+            table_ref=wi.fqn, stage_name="L2 stage_b",
+            step_errors=[("stage_b", ValueError("B_FAILED: raw=0.5"))],
+            stage_a=_stage_a(), stage_b=_stage_b_failed(),
+            metrics=StageMetrics(),
+            llm_attempts=[att],
+        )
+
+        with patch(
+            "sema.pipeline.build._run_pipeline_stages",
+            side_effect=err,
+        ):
+            result = process_table(
+                wi, connector, llm_client, loader,
+                run_id="run-1",
+                eval_dump_dir=str(tmp_path),
+                eval_config_label="run",
+            )
+
+        assert result.status == "failed"
+        path = tmp_path / "patient__run__failure.json"
+        assert path.exists()
+        data = json.loads(path.read_text())
+        assert data["failure_classification"] == "semantic_coverage"
+        assert data["stage_a_output"] is not None
+
+    def test_circuit_open_writes_artifact(self, tmp_path):
+        from sema.connectors.databricks import TableWorkItem
+        from sema.pipeline.build import process_table
+
+        loader = MagicMock()
+        loader.has_assertions.return_value = False
+        connector = MagicMock()
+        llm_client = MagicMock()
+
+        wi = TableWorkItem(
+            catalog="cat", schema="sch",
+            table_name="mutation",
+            fqn="databricks://ws/cat/sch/mutation",
+        )
+
+        with patch(
+            "sema.pipeline.build._run_pipeline_stages",
+            side_effect=CircuitOpenError("circuit open"),
+        ):
+            result = process_table(
+                wi, connector, llm_client, loader,
+                run_id="run-1",
+                eval_dump_dir=str(tmp_path),
+                eval_config_label="run",
+            )
+
+        assert result.status == "failed"
+        path = tmp_path / "mutation__run__failure.json"
+        assert path.exists()
+        data = json.loads(path.read_text())
+        assert data["failure_classification"] == "circuit_open"
+        assert data["failure_stage"] == "circuit_breaker"
+
+    def test_no_eval_dump_dir_writes_no_artifact(self, tmp_path):
+        from sema.connectors.databricks import TableWorkItem
+        from sema.pipeline.build import process_table
+
+        loader = MagicMock()
+        loader.has_assertions.return_value = False
+        connector = MagicMock()
+        llm_client = MagicMock()
+
+        wi = TableWorkItem(
+            catalog="cat", schema="sch",
+            table_name="patient",
+            fqn="databricks://ws/cat/sch/patient",
+        )
+
+        with patch(
+            "sema.pipeline.build._run_pipeline_stages",
+            side_effect=LLMStageError(
+                table_ref=wi.fqn, stage_name="L2 stage_a",
+                step_errors=[], llm_attempts=[],
+            ),
+        ):
+            result = process_table(
+                wi, connector, llm_client, loader,
+                run_id="run-1",
+                eval_dump_dir=None,
+            )
+        assert result.status == "failed"
+        # No file was written anywhere
+        assert list(tmp_path.glob("*__failure.json")) == []
+
+    def test_artifact_write_failure_does_not_propagate(self, tmp_path):
+        """OSError during artifact write must be logged + swallowed."""
+        from sema.connectors.databricks import TableWorkItem
+        from sema.pipeline.build import process_table
+
+        loader = MagicMock()
+        loader.has_assertions.return_value = False
+        connector = MagicMock()
+        llm_client = MagicMock()
+
+        wi = TableWorkItem(
+            catalog="cat", schema="sch",
+            table_name="patient",
+            fqn="databricks://ws/cat/sch/patient",
+        )
+
+        err = LLMStageError(
+            table_ref=wi.fqn, stage_name="L2 stage_a",
+            step_errors=[], llm_attempts=[],
+        )
+
+        with patch(
+            "sema.pipeline.build._run_pipeline_stages",
+            side_effect=err,
+        ), patch(
+            "sema.eval.failure_artifact.dump_table_failure_artifact",
+            side_effect=OSError("disk full"),
+        ):
+            result = process_table(
+                wi, connector, llm_client, loader,
+                run_id="run-1",
+                eval_dump_dir=str(tmp_path),
+            )
+
+        assert result.status == "failed"
+
+    def test_success_path_writes_no_failure_artifact(self):
+        # Existing successful runs continue to write only telemetry.
+        # Here we only verify failure module isn't called for success.
+        # End-to-end success behavior is covered by other tests.
+        from sema.eval.failure_artifact import dump_table_failure_artifact
+        # Smoke import only — no behavior to assert here.
+        assert callable(dump_table_failure_artifact)

--- a/tests/unit/test_llm_client.py
+++ b/tests/unit/test_llm_client.py
@@ -542,3 +542,289 @@ class TestLLMStageError:
 
         generic_err = Exception("something else")
         assert _is_transient_error(generic_err) is False
+
+
+# ---------------------------------------------------------------------------
+# Service-health classification tests (Section 1 — opt-in breaker semantics)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestServiceHealthClassification:
+    def test_http_503_is_service_health(self):
+        from sema.llm_client import _is_service_health_failure
+        err = Exception("Service Unavailable")
+        err.status_code = 503
+        assert _is_service_health_failure(err) is True
+
+    def test_http_500_is_service_health(self):
+        from sema.llm_client import _is_service_health_failure
+        err = Exception("Internal Server Error")
+        err.status_code = 500
+        assert _is_service_health_failure(err) is True
+
+    def test_http_502_is_service_health(self):
+        from sema.llm_client import _is_service_health_failure
+        err = Exception("Bad Gateway")
+        err.status_code = 502
+        assert _is_service_health_failure(err) is True
+
+    def test_http_504_is_service_health(self):
+        from sema.llm_client import _is_service_health_failure
+        err = Exception("Gateway Timeout")
+        err.status_code = 504
+        assert _is_service_health_failure(err) is True
+
+    def test_http_429_is_not_service_health(self):
+        from sema.llm_client import _is_service_health_failure
+        err = Exception("Too Many Requests")
+        err.status_code = 429
+        assert _is_service_health_failure(err) is False
+
+    def test_rate_limit_message_is_not_service_health(self):
+        from sema.llm_client import _is_service_health_failure
+        err = Exception("REQUEST_LIMIT_EXCEEDED: tokens/min")
+        assert _is_service_health_failure(err) is False
+
+    def test_json_decode_error_is_not_service_health(self):
+        from sema.llm_client import _is_service_health_failure
+        err = json.JSONDecodeError("bad json", "", 0)
+        assert _is_service_health_failure(err) is False
+
+    def test_pydantic_validation_error_is_not_service_health(self):
+        from pydantic import ValidationError as PydValidationError
+        from sema.llm_client import _is_service_health_failure
+
+        class _S(BaseModel):
+            x: int
+        try:
+            _S.model_validate({"x": "not-an-int"})
+        except PydValidationError as exc:
+            assert _is_service_health_failure(exc) is False
+            return
+        pytest.fail("ValidationError should have been raised")
+
+    def test_value_error_no_json_found_is_not_service_health(self):
+        from sema.llm_client import _is_service_health_failure
+        err = ValueError("No JSON found in LLM response: ...")
+        assert _is_service_health_failure(err) is False
+
+    def test_value_error_could_not_parse_is_not_service_health(self):
+        from sema.llm_client import _is_service_health_failure
+        err = ValueError("Could not parse LLM response into TableSummary: ...")
+        assert _is_service_health_failure(err) is False
+
+    def test_value_error_b_failed_is_not_service_health_defensive(self):
+        """Defensive: B_FAILED ValueError currently does not flow through
+        LLMClient.invoke (raised at semantic.py:450, outside invoke).
+        If a future refactor routes it through, the breaker must not trip."""
+        from sema.llm_client import _is_service_health_failure
+        err = ValueError("B_FAILED: raw=0.65")
+        assert _is_service_health_failure(err) is False
+
+    def test_unknown_exception_is_not_service_health(self):
+        from sema.llm_client import _is_service_health_failure
+        err = RuntimeError("something unexpected")
+        assert _is_service_health_failure(err) is False
+
+    def test_connection_error_is_service_health(self):
+        from sema.llm_client import _is_service_health_failure
+        err = ConnectionError("Connection refused")
+        assert _is_service_health_failure(err) is True
+
+    def test_timeout_error_is_service_health(self):
+        from sema.llm_client import _is_service_health_failure
+        err = TimeoutError("socket read timed out")
+        assert _is_service_health_failure(err) is True
+
+
+@pytest.mark.unit
+class TestCircuitBreakerOptInService:
+    """Section 1: breaker only records service-health failures.
+
+    The cascade-pollution path is per-batch invokes inside
+    `_invoke_stage_b_batch`: content failures from `LLMClient.invoke`."""
+
+    def _client_for(self, llm, breaker):
+        return LLMClient(
+            llm, retry_max_attempts=1, retry_base_delay=0.01,
+            circuit_breaker=breaker,
+        )
+
+    def test_503_step_error_records_breaker(self):
+        llm = MagicMock(spec=["invoke"])
+        err = Exception("Service Unavailable")
+        err.status_code = 503
+        llm.invoke.side_effect = err
+        breaker = MagicMock()
+        breaker.check.return_value = None
+
+        with patch("sema.llm_client.time.sleep"):
+            client = self._client_for(llm, breaker)
+            with pytest.raises(LLMStageError):
+                client.invoke(
+                    "p", TableSummary, table_ref="r", stage_name="s",
+                )
+        breaker.record_failure.assert_called_once()
+
+    def test_429_step_error_does_not_record(self):
+        llm = MagicMock(spec=["invoke"])
+        err = Exception("rate limit")
+        err.status_code = 429
+        llm.invoke.side_effect = err
+        breaker = MagicMock()
+        breaker.check.return_value = None
+
+        with patch("sema.llm_client.time.sleep"):
+            client = self._client_for(llm, breaker)
+            with pytest.raises(LLMStageError):
+                client.invoke(
+                    "p", TableSummary, table_ref="r", stage_name="s",
+                )
+        breaker.record_failure.assert_not_called()
+
+    def test_json_decode_step_error_does_not_record(self):
+        """Per-batch content-failure storm must not trip the breaker."""
+        llm = MagicMock(spec=["invoke"])
+        response = MagicMock()
+        response.content = "not valid json at all"
+        llm.invoke.return_value = response
+        breaker = MagicMock()
+        breaker.check.return_value = None
+
+        client = self._client_for(llm, breaker)
+        with pytest.raises(LLMStageError):
+            client.invoke(
+                "p", TableSummary, table_ref="r", stage_name="s",
+            )
+        breaker.record_failure.assert_not_called()
+
+    def test_value_error_no_json_does_not_record(self):
+        llm = MagicMock(spec=["invoke"])
+        response = MagicMock()
+        response.content = "i cannot help with that request"
+        llm.invoke.return_value = response
+        breaker = MagicMock()
+        breaker.check.return_value = None
+
+        client = self._client_for(llm, breaker)
+        with pytest.raises(LLMStageError):
+            client.invoke(
+                "p", TableSummary, table_ref="r", stage_name="s",
+            )
+        breaker.record_failure.assert_not_called()
+
+    def test_mixed_503_and_json_decode_records(self):
+        """When step_errors carry [(structured, JSONDecodeError),
+        (plain, 503)], the breaker SHALL record because at least one is
+        service-health."""
+        llm = MagicMock()
+        structured_llm = MagicMock()
+        structured_llm.invoke.side_effect = json.JSONDecodeError(
+            "bad", "", 0,
+        )
+        llm.with_structured_output.return_value = structured_llm
+
+        err503 = Exception("Service Unavailable")
+        err503.status_code = 503
+        llm.invoke.side_effect = err503
+
+        breaker = MagicMock()
+        breaker.check.return_value = None
+
+        with patch("sema.llm_client.time.sleep"):
+            client = LLMClient(
+                llm, retry_max_attempts=1, retry_base_delay=0.01,
+                use_structured_output="true",
+                circuit_breaker=breaker,
+            )
+            with pytest.raises(LLMStageError):
+                client.invoke(
+                    "p", TableSummary, table_ref="r", stage_name="s",
+                )
+        breaker.record_failure.assert_called_once()
+
+    def test_unknown_exception_does_not_record(self):
+        llm = MagicMock(spec=["invoke"])
+        llm.invoke.side_effect = RuntimeError("mystery")
+        breaker = MagicMock()
+        breaker.check.return_value = None
+
+        client = self._client_for(llm, breaker)
+        with pytest.raises(LLMStageError):
+            client.invoke(
+                "p", TableSummary, table_ref="r", stage_name="s",
+            )
+        breaker.record_failure.assert_not_called()
+
+    def test_b_failed_synthetic_value_error_does_not_record_defensive(self):
+        """Defensive: synthetic `B_FAILED` `LLMStageError` currently never
+        flows through `LLMClient.invoke` (raised at semantic.py:450,
+        outside invoke). If a future refactor routes it through, the
+        breaker SHALL still not trip on the contained ValueError."""
+        from sema.llm_client import _is_service_health_failure
+
+        synthetic = ValueError("B_FAILED: raw=0.65")
+        assert _is_service_health_failure(synthetic) is False
+
+        stage_err = LLMStageError(
+            table_ref="r",
+            stage_name="L2 stage_b",
+            step_errors=[("stage_b", synthetic)],
+        )
+        assert all(
+            not _is_service_health_failure(e)
+            for _, e in stage_err.step_errors
+        )
+
+
+@pytest.mark.unit
+class TestRetryPolicyUnchanged:
+    """Section 1.5: keep retry-backoff selection independent of breaker
+    classification — a service-health 503 still uses the retry backoff
+    schedule, not the rate-limit one."""
+
+    def test_503_uses_short_retry_backoff_not_rate_limit_schedule(self):
+        llm = MagicMock(spec=["invoke"])
+        err = Exception("Service Unavailable")
+        err.status_code = 503
+        llm.invoke.side_effect = err
+
+        sleep_times: list[float] = []
+        with patch("sema.llm_client.time.sleep") as mock_sleep:
+            mock_sleep.side_effect = lambda t: sleep_times.append(t)
+            client = LLMClient(
+                llm, retry_max_attempts=3, retry_base_delay=2.0,
+                retry_multiplier=2.0, retry_jitter=0.0,
+                rate_limit_base_delay=10.0,
+            )
+            with pytest.raises(LLMStageError):
+                client.invoke(
+                    "p", TableSummary, table_ref="r", stage_name="s",
+                )
+
+        assert len(sleep_times) == 2
+        # Short retry schedule, not the long rate-limit one
+        assert sleep_times[0] == pytest.approx(2.0, abs=0.1)
+        assert sleep_times[1] == pytest.approx(4.0, abs=0.1)
+
+    def test_429_still_uses_long_rate_limit_backoff(self):
+        llm = MagicMock(spec=["invoke"])
+        err = Exception("rate limit")
+        err.status_code = 429
+        llm.invoke.side_effect = err
+
+        sleep_times: list[float] = []
+        with patch("sema.llm_client.time.sleep") as mock_sleep:
+            mock_sleep.side_effect = lambda t: sleep_times.append(t)
+            client = LLMClient(
+                llm, retry_max_attempts=3, retry_base_delay=2.0,
+                rate_limit_base_delay=10.0, retry_jitter=0.0,
+            )
+            with pytest.raises(LLMStageError):
+                client.invoke(
+                    "p", TableSummary, table_ref="r", stage_name="s",
+                )
+
+        assert len(sleep_times) == 2
+        assert sleep_times[0] >= 10.0
+        assert sleep_times[1] >= 30.0

--- a/tests/unit/test_metadata_tier.py
+++ b/tests/unit/test_metadata_tier.py
@@ -1,0 +1,110 @@
+"""Metadata tier classifier (Section 5b)."""
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _evidence(
+    *,
+    n_cols: int = 4,
+    cols_with_comment: int = 0,
+    table_comment: str | None = None,
+    cols_with_top_values: int = 0,
+    sample_rows: list | None = None,
+) -> dict:
+    cols = []
+    for i in range(n_cols):
+        c = {"name": f"c{i}", "data_type": "STRING"}
+        if i < cols_with_comment:
+            c["column_comment"] = f"comment for c{i}"
+        if i < cols_with_top_values:
+            c["top_values"] = [{"value": "x", "count": 1}]
+        cols.append(c)
+    return {
+        "table_name": "t",
+        "table_ref": "unity://cat/sch/t",
+        "columns": cols,
+        "table_comment": table_comment or "",
+        "sample_rows": sample_rows or [],
+    }
+
+
+class TestClassifyMetadataTier:
+    def test_full_column_comments_with_table_comment_is_rich(self):
+        from sema.engine.metadata_tier import classify_metadata_tier
+        ev = _evidence(
+            n_cols=10, cols_with_comment=10,
+            table_comment="Patient demographic table",
+        )
+        assert classify_metadata_tier(ev) == "rich"
+
+    def test_zero_evidence_is_name_only(self):
+        from sema.engine.metadata_tier import classify_metadata_tier
+        ev = _evidence(n_cols=14)
+        assert classify_metadata_tier(ev) == "name_only"
+
+    def test_partial_evidence_is_sparse(self):
+        from sema.engine.metadata_tier import classify_metadata_tier
+        ev = _evidence(
+            n_cols=14, cols_with_comment=0,
+            cols_with_top_values=8,
+        )
+        assert classify_metadata_tier(ev) == "sparse"
+
+    def test_some_comments_below_floor_is_sparse(self):
+        from sema.engine.metadata_tier import classify_metadata_tier
+        # 3/14 = 0.21 — below default rich floor (0.60)
+        ev = _evidence(n_cols=14, cols_with_comment=3)
+        assert classify_metadata_tier(ev) == "sparse"
+
+    def test_source_agnostic_same_evidence_same_tier(self):
+        from sema.engine.metadata_tier import classify_metadata_tier
+        ev_omop = _evidence(n_cols=14)
+        ev_omop["table_ref"] = "unity://omop_v5/clinical/person"
+        ev_cbio = _evidence(n_cols=14)
+        ev_cbio["table_ref"] = "unity://cbioportal/brca/patient"
+        assert classify_metadata_tier(ev_omop) == "name_only"
+        assert classify_metadata_tier(ev_cbio) == "name_only"
+
+    def test_pure_no_io(self):
+        """Classifier must be pure — repeated calls produce same output."""
+        from sema.engine.metadata_tier import classify_metadata_tier
+        ev = _evidence(n_cols=10, cols_with_comment=10, table_comment="x")
+        assert classify_metadata_tier(ev) == classify_metadata_tier(ev)
+
+    def test_rich_floor_knob_shifts_threshold(self):
+        from sema.engine.metadata_tier import classify_metadata_tier
+        # 3/10 = 0.30 column comments
+        ev = _evidence(n_cols=10, cols_with_comment=3, table_comment="x")
+        # Default 0.60 floor: not enough → sparse
+        assert classify_metadata_tier(ev) == "sparse"
+        # Lowered to 0.20 floor: passes → rich
+        assert classify_metadata_tier(ev, rich_floor=0.20) == "rich"
+
+
+class TestRichTierAccessoryConditions:
+    def test_rich_requires_one_of_table_comment_top_values_or_samples(self):
+        from sema.engine.metadata_tier import classify_metadata_tier
+        # 100% column comments but no other evidence → still requires
+        # table_comment / top_values / sample_rows for rich
+        ev = _evidence(n_cols=10, cols_with_comment=10)
+        # No table_comment, no top_values, no sample_rows
+        assert classify_metadata_tier(ev) == "sparse"
+
+    def test_rich_with_top_values_majority(self):
+        from sema.engine.metadata_tier import classify_metadata_tier
+        ev = _evidence(
+            n_cols=10, cols_with_comment=10,
+            cols_with_top_values=6,  # 60% — meets the >=50% floor
+        )
+        assert classify_metadata_tier(ev) == "rich"
+
+    def test_rich_with_sample_rows(self):
+        from sema.engine.metadata_tier import classify_metadata_tier
+        ev = _evidence(
+            n_cols=10, cols_with_comment=10,
+            sample_rows=[{"c0": "a"}],
+        )
+        assert classify_metadata_tier(ev) == "rich"

--- a/tests/unit/test_orchestrate_resume_gating.py
+++ b/tests/unit/test_orchestrate_resume_gating.py
@@ -1,0 +1,275 @@
+"""Resume gating: schema-wipe loop must NOT run when --resume is set."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _build_config(resume: bool, schemas: list[str]):
+    from sema.models.config import (
+        BuildConfig,
+        DatabricksConfig,
+        LLMConfig,
+        Neo4jConfig,
+    )
+    return BuildConfig(
+        catalog="cat",
+        schemas=schemas,
+        skip_embeddings=True,
+        resume=resume,
+        databricks=DatabricksConfig(),
+        neo4j=Neo4jConfig(),
+        llm=LLMConfig(),
+    )
+
+
+def _patch_run_build(work_items_for_schemas: list[str]):
+    from sema.pipeline.build import TableResult, TableWorkItem
+
+    work_items = [
+        TableWorkItem(
+            catalog="cat",
+            schema=s,
+            table_name=f"tbl_{s}",
+            fqn=f"unity://cat.{s}.tbl_{s}",
+        )
+        for s in work_items_for_schemas
+    ]
+    return work_items
+
+
+@pytest.fixture
+def loader_and_driver():
+    driver = MagicMock()
+    loader = MagicMock()
+    return driver, loader
+
+
+def _common_patches(work_items, results=None):
+    """Patch the heavy collaborators of run_build so we can isolate
+    the schema-wipe gating behavior."""
+    if results is None:
+        from sema.pipeline.build import TableResult
+        results = [
+            TableResult.success(wi.fqn, entities=1, properties=1, terms=0)
+            for wi in work_items
+        ]
+    return results
+
+
+class TestResumeGating:
+    def test_resume_true_does_not_wipe_assertions(self, loader_and_driver):
+        driver, loader = loader_and_driver
+        work_items = _patch_run_build(["sch1", "sch2"])
+        results = _common_patches(work_items)
+
+        cfg = _build_config(resume=True, schemas=["sch1", "sch2"])
+        with patch(
+            "sema.pipeline.orchestrate._get_neo4j_driver",
+            return_value=driver,
+        ), patch(
+            "sema.graph.loader.GraphLoader", return_value=loader,
+        ), patch(
+            "sema.connectors.databricks.DatabricksConnector",
+        ) as conn_cls, patch(
+            "sema.pipeline.orchestrate._register_datasource",
+        ), patch(
+            "sema.pipeline.orchestrate._discover_tables",
+            return_value=work_items,
+        ), patch(
+            "sema.pipeline.orchestrate._spawn_workers",
+            return_value=results,
+        ), patch(
+            "sema.pipeline.orchestrate.run_fk_detection",
+        ), patch(
+            "sema.pipeline.orchestrate._compute_embeddings",
+        ), patch(
+            "sema.pipeline.profiler.WarehouseProfiler",
+        ) as profiler_cls, patch(
+            "sema.pipeline.orchestrate.resolve_domain_context",
+            return_value=__import__(
+                "sema.models.domain", fromlist=["DomainContext"],
+            ).DomainContext(),
+        ):
+            conn = MagicMock()
+            conn.get_datasource_ref.return_value = (
+                "unity://cat", "cat", "src",
+            )
+            conn_cls.return_value = conn
+            profiler = MagicMock()
+            profiler.profile.return_value = MagicMock()
+            profiler_cls.return_value = profiler
+
+            from sema.pipeline.orchestrate import run_build
+            run_build(cfg)
+
+        loader.delete_study_scoped.assert_not_called()
+
+    def test_resume_false_wipes_each_schema_once(self, loader_and_driver):
+        driver, loader = loader_and_driver
+        work_items = _patch_run_build(["sch1", "sch2", "sch1"])
+        results = _common_patches(work_items)
+
+        cfg = _build_config(resume=False, schemas=["sch1", "sch2"])
+        with patch(
+            "sema.pipeline.orchestrate._get_neo4j_driver",
+            return_value=driver,
+        ), patch(
+            "sema.graph.loader.GraphLoader", return_value=loader,
+        ), patch(
+            "sema.connectors.databricks.DatabricksConnector",
+        ) as conn_cls, patch(
+            "sema.pipeline.orchestrate._register_datasource",
+        ), patch(
+            "sema.pipeline.orchestrate._discover_tables",
+            return_value=work_items,
+        ), patch(
+            "sema.pipeline.orchestrate._spawn_workers",
+            return_value=results,
+        ), patch(
+            "sema.pipeline.orchestrate.run_fk_detection",
+        ), patch(
+            "sema.pipeline.orchestrate._compute_embeddings",
+        ), patch(
+            "sema.pipeline.profiler.WarehouseProfiler",
+        ) as profiler_cls, patch(
+            "sema.pipeline.orchestrate.resolve_domain_context",
+            return_value=__import__(
+                "sema.models.domain", fromlist=["DomainContext"],
+            ).DomainContext(),
+        ):
+            conn = MagicMock()
+            conn.get_datasource_ref.return_value = (
+                "unity://cat", "cat", "src",
+            )
+            conn_cls.return_value = conn
+            profiler = MagicMock()
+            profiler.profile.return_value = MagicMock()
+            profiler_cls.return_value = profiler
+
+            from sema.pipeline.orchestrate import run_build
+            run_build(cfg)
+
+        called_schemas = sorted(
+            c.args[0] for c in loader.delete_study_scoped.call_args_list
+        )
+        assert called_schemas == ["sch1", "sch2"]
+
+    def test_resume_true_no_prior_data_skips_wipe(self, loader_and_driver):
+        driver, loader = loader_and_driver
+        loader.has_assertions.return_value = False
+        work_items = _patch_run_build(["sch1"])
+        results = _common_patches(work_items)
+
+        cfg = _build_config(resume=True, schemas=["sch1"])
+        with patch(
+            "sema.pipeline.orchestrate._get_neo4j_driver",
+            return_value=driver,
+        ), patch(
+            "sema.graph.loader.GraphLoader", return_value=loader,
+        ), patch(
+            "sema.connectors.databricks.DatabricksConnector",
+        ) as conn_cls, patch(
+            "sema.pipeline.orchestrate._register_datasource",
+        ), patch(
+            "sema.pipeline.orchestrate._discover_tables",
+            return_value=work_items,
+        ), patch(
+            "sema.pipeline.orchestrate._spawn_workers",
+            return_value=results,
+        ), patch(
+            "sema.pipeline.orchestrate.run_fk_detection",
+        ), patch(
+            "sema.pipeline.orchestrate._compute_embeddings",
+        ), patch(
+            "sema.pipeline.profiler.WarehouseProfiler",
+        ) as profiler_cls, patch(
+            "sema.pipeline.orchestrate.resolve_domain_context",
+            return_value=__import__(
+                "sema.models.domain", fromlist=["DomainContext"],
+            ).DomainContext(),
+        ):
+            conn = MagicMock()
+            conn.get_datasource_ref.return_value = (
+                "unity://cat", "cat", "src",
+            )
+            conn_cls.return_value = conn
+            profiler = MagicMock()
+            profiler.profile.return_value = MagicMock()
+            profiler_cls.return_value = profiler
+
+            from sema.pipeline.orchestrate import run_build
+            run_build(cfg)
+
+        loader.delete_study_scoped.assert_not_called()
+
+
+class TestProcessTableResumeWithAssertions:
+    """Worker-level: with resume=True and existing assertions,
+    process_table SHALL return TableResult.skipped without invoking LLM."""
+
+    def test_returns_skipped_when_assertions_exist(self):
+        from sema.pipeline.build import (
+            TableWorkItem, process_table,
+        )
+
+        loader = MagicMock()
+        loader.has_assertions.return_value = True
+        loader.load_assertions.return_value = []
+        connector = MagicMock()
+        llm_client = MagicMock()
+
+        wi = TableWorkItem(
+            catalog="cat", schema="sch1",
+            table_name="patient",
+            fqn="unity://cat.sch1.patient",
+        )
+        with patch(
+            "sema.graph.materializer.materialize_unified",
+        ) as mat:
+            result = process_table(
+                wi, connector, llm_client, loader,
+                run_id="rid", resume=True,
+            )
+
+        assert result.status == "skipped"
+        assert "resume" in (result.skip_reason or "")
+        connector.assert_not_called()
+        llm_client.invoke.assert_not_called()
+        # materialize_unified MUST receive source_schema — Neo4j rejects
+        # MERGE on relationships with null source_schema property.
+        assert mat.called
+        kwargs = mat.call_args.kwargs
+        assert kwargs.get("source_schema") == "sch1"
+
+    def test_returns_full_pipeline_when_no_assertions(self):
+        """When resume=True but no assertions exist, full pipeline runs."""
+        from sema.pipeline.build import (
+            TableWorkItem, process_table,
+        )
+
+        loader = MagicMock()
+        loader.has_assertions.return_value = False
+        connector = MagicMock()
+        llm_client = MagicMock()
+
+        wi = TableWorkItem(
+            catalog="cat", schema="sch1",
+            table_name="patient",
+            fqn="unity://cat.sch1.patient",
+        )
+        with patch(
+            "sema.pipeline.build._run_pipeline_stages",
+            side_effect=Exception("forced exit after gate"),
+        ):
+            result = process_table(
+                wi, connector, llm_client, loader,
+                run_id="rid", resume=True,
+            )
+
+        # _run_pipeline_stages was reached, then raised — so resume
+        # short-circuit was NOT taken.
+        assert result.status == "failed"

--- a/tests/unit/test_quality_budget.py
+++ b/tests/unit/test_quality_budget.py
@@ -1,0 +1,226 @@
+"""Run-level quality budget (Section 6)."""
+from __future__ import annotations
+
+import pytest
+
+from sema.models.config import BuildConfig
+from sema.pipeline.build import TableResult
+
+pytestmark = pytest.mark.unit
+
+
+def _failed(table_ref: str, stage: str, reason: str = "fail",
+            tier: str | None = None) -> TableResult:
+    return TableResult.failed(table_ref, stage, reason, metadata_tier=tier)
+
+
+def _success(table_ref: str, partial: bool = False,
+             tier: str | None = None) -> TableResult:
+    return TableResult.success(
+        table_ref, entities=1, properties=1,
+        partial=partial, metadata_tier=tier,
+    )
+
+
+def _skipped(table_ref: str, reason: str) -> TableResult:
+    return TableResult.skipped(table_ref, reason)
+
+
+def _cfg(**overrides) -> BuildConfig:
+    base = BuildConfig()
+    for k, v in overrides.items():
+        setattr(base, k, v)
+    return base
+
+
+class TestComputeBreakdown:
+    def test_separates_skipped_resume_from_skipped_other(self):
+        from sema.pipeline.quality_budget import compute_breakdown
+
+        results = [
+            _success("t1"),
+            _skipped("t2", "resume: assertions exist"),
+            _skipped("t3", "no table metadata"),
+        ]
+        b = compute_breakdown(results)
+        assert b.succeeded == 1
+        assert b.skipped_resume == 1
+        assert b.skipped_other == 1
+
+    def test_classifies_failure_categories(self):
+        from sema.pipeline.quality_budget import compute_breakdown
+
+        results = [
+            _failed("t1", "L2 stage_b"),
+            _failed("t2", "L2 stage_a"),
+            _failed("t3", "circuit_breaker"),
+            _failed("t4", "unknown"),
+        ]
+        b = compute_breakdown(results)
+        assert b.stage_b_failed == 1
+        assert b.stage_a_failed == 1
+        assert b.circuit_open == 1
+        assert b.other_failed == 1
+
+
+class TestStageBBudget:
+    def test_40pct_b_failed_triggers(self):
+        from sema.pipeline.quality_budget import (
+            QualityBudgetExceeded, enforce_quality_budget,
+        )
+
+        # 12 b_failed / 30 graph-contributing = 0.40
+        results = (
+            [_success(f"s{i}") for i in range(18)]
+            + [_failed(f"f{i}", "L2 stage_b") for i in range(12)]
+        )
+        with pytest.raises(QualityBudgetExceeded) as exc_info:
+            enforce_quality_budget(results, _cfg())
+
+        err = exc_info.value
+        assert err.trigger == "stage_b_failure_rate"
+
+    def test_20pct_b_failed_does_not_trigger(self):
+        from sema.pipeline.quality_budget import enforce_quality_budget
+
+        results = (
+            [_success(f"s{i}") for i in range(24)]
+            + [_failed(f"f{i}", "L2 stage_b") for i in range(6)]
+        )
+        # No raise
+        enforce_quality_budget(results, _cfg())
+
+    def test_tiny_run_below_min_processed(self):
+        from sema.pipeline.quality_budget import enforce_quality_budget
+
+        results = [
+            _success("s1"),
+            _failed("f1", "L2 stage_b"),
+            _failed("f2", "L2 stage_b"),
+        ]
+        # Under 5-table min — no raise even at 67% rate
+        enforce_quality_budget(results, _cfg())
+
+    def test_circuit_open_excluded_from_trigger1(self):
+        from sema.pipeline.quality_budget import enforce_quality_budget
+
+        # 4 b_failed / 30 graph-contributing = 0.133, no trigger 1
+        # But 3 circuit_open + 4 stage_b_failed → 7/30 = 0.233, no T2
+        results = (
+            [_success(f"s{i}") for i in range(23)]
+            + [_failed(f"f{i}", "L2 stage_b") for i in range(4)]
+            + [_failed(f"co{i}", "circuit_breaker") for i in range(3)]
+        )
+        enforce_quality_budget(results, _cfg())
+
+    def test_resume_retry_b_failed_within_budget(self):
+        """Resume of 8 against 29 prior, all 8 hit Stage B fail.
+        T1 denominator counts 29 skipped_resume → rate = 8/37 = 0.216
+        which stays under 0.30. T2 denominator = 8 (excludes resume),
+        non_contributing numerator = 0 (stage_b is graph-contributing)
+        → rate = 0. Run continues."""
+        from sema.pipeline.quality_budget import enforce_quality_budget
+
+        results = (
+            [_failed(f"f{i}", "L2 stage_b") for i in range(8)]
+            + [_skipped(f"s{i}", "resume: ok") for i in range(29)]
+        )
+        # Should NOT raise
+        enforce_quality_budget(results, _cfg())
+
+
+class TestRunReliabilityBudget:
+    def test_resume_retry_all_stage_a_storm(self):
+        """All 8 retries hit stage_a — trigger 2 fires."""
+        from sema.pipeline.quality_budget import (
+            QualityBudgetExceeded, enforce_quality_budget,
+        )
+
+        # 8 stage_a_failed, 29 skipped_resume
+        # T1: 0 / (0 + 0 + 29) = 0 → no trigger
+        # T2: 8 / (0 + 8 + 0) = 1.0 → triggers
+        results = (
+            [_failed(f"f{i}", "L2 stage_a") for i in range(8)]
+            + [_skipped(f"s{i}", "resume: ok") for i in range(29)]
+        )
+        with pytest.raises(QualityBudgetExceeded) as exc_info:
+            enforce_quality_budget(results, _cfg())
+        assert exc_info.value.trigger == "run_non_contributing_rate"
+
+    def test_healthy_run_stays_under(self):
+        from sema.pipeline.quality_budget import enforce_quality_budget
+
+        # 25 success, 3 b_fail, 2 stage_a_fail
+        # T1: 3/28 ≈ 0.107 → no
+        # T2: 2/30 ≈ 0.067 → no
+        results = (
+            [_success(f"s{i}") for i in range(25)]
+            + [_failed(f"b{i}", "L2 stage_b") for i in range(3)]
+            + [_failed(f"a{i}", "L2 stage_a") for i in range(2)]
+        )
+        enforce_quality_budget(results, _cfg())
+
+    def test_skipped_other_excluded_from_t1_included_in_t2(self):
+        from sema.pipeline.quality_budget import compute_breakdown
+
+        results = [
+            _success("s1"), _success("s2"), _success("s3"),
+            _success("s4"), _success("s5"),
+            _skipped("sk1", "no table metadata"),  # skipped_other
+        ]
+        b = compute_breakdown(results)
+        assert b.skipped_other == 1
+        assert b.skipped_resume == 0
+
+
+class TestStableOrdering:
+    def test_both_triggers_exceed_t1_fires_first(self):
+        from sema.pipeline.quality_budget import (
+            QualityBudgetExceeded, enforce_quality_budget,
+        )
+
+        # 3 ok, 5 b_fail, 22 circuit_open
+        # T1: 5 / (3 + 5 + 0) = 0.625 → exceeds 0.30
+        # T2: 22 / (3 + 27 + 0) = 0.733 → exceeds 0.40
+        results = (
+            [_success(f"s{i}") for i in range(3)]
+            + [_failed(f"b{i}", "L2 stage_b") for i in range(5)]
+            + [_failed(f"co{i}", "circuit_breaker") for i in range(22)]
+        )
+        with pytest.raises(QualityBudgetExceeded) as exc_info:
+            enforce_quality_budget(results, _cfg())
+        assert exc_info.value.trigger == "stage_b_failure_rate"
+
+
+class TestDisableFlag:
+    def test_no_quality_budget_disables_both(self):
+        from sema.pipeline.quality_budget import enforce_quality_budget
+
+        results = [_failed(f"f{i}", "L2 stage_b") for i in range(35)]
+        cfg = _cfg(
+            quality_budget_max_failure_rate=1.0,
+            quality_budget_max_non_contributing_rate=1.0,
+        )
+        enforce_quality_budget(results, cfg)
+
+
+class TestExceptionFields:
+    def test_stage_b_trigger_carries_breakdown(self):
+        from sema.pipeline.quality_budget import (
+            QualityBudgetExceeded, enforce_quality_budget,
+        )
+
+        results = (
+            [_success(f"s{i}") for i in range(18)]
+            + [_failed(f"f{i}", "L2 stage_b") for i in range(12)]
+        )
+        with pytest.raises(QualityBudgetExceeded) as exc_info:
+            enforce_quality_budget(results, _cfg())
+        err = exc_info.value
+        assert err.trigger == "stage_b_failure_rate"
+        assert err.failure_rate == pytest.approx(12/30, abs=0.001)
+        assert err.threshold == 0.30
+        assert err.denominator == 30
+        b = err.breakdown
+        assert b["stage_b_failed"] == 12
+        assert b["succeeded"] == 18

--- a/tests/unit/test_semantic_llm_attempts.py
+++ b/tests/unit/test_semantic_llm_attempts.py
@@ -1,0 +1,189 @@
+"""Engine-local LLM-attempt buffer (Section 3 of stage-b-failure-containment).
+
+Captures forensics for every LLMClient.invoke call during a single
+interpret_table_* execution. Opt-in via the engine's capture flag.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from sema.engine.semantic import SemanticEngine
+from sema.llm_client import LLMClient, LLMStageError
+from sema.models.stages import (
+    StageAResult,
+    StageBBatchResult,
+    StageBColumnResult,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _meta() -> dict:
+    return {
+        "table_ref": "unity://cdm.clinical.patient",
+        "table_name": "patient",
+        "columns": [
+            {"name": "patient_id", "data_type": "STRING"},
+            {"name": "age", "data_type": "INTEGER"},
+        ],
+        "sample_rows": [],
+        "comment": None,
+    }
+
+
+def _stage_a() -> StageAResult:
+    return StageAResult(
+        primary_entity="Patient",
+        grain_hypothesis="one row per patient",
+        confidence=0.9,
+    )
+
+
+def _stage_b_one_col(col: str) -> StageBBatchResult:
+    return StageBBatchResult(columns=[
+        StageBColumnResult(
+            column=col,
+            canonical_property_label=col,
+            semantic_type="identifier",
+            entity_role="primary_key",
+            needs_stage_c=False,
+        ),
+    ])
+
+
+class TestLLMAttemptModel:
+    def test_attempt_dataclass_fields(self):
+        from sema.engine.semantic_utils import LLMAttempt
+
+        a = LLMAttempt(
+            stage="L2 stage_a",
+            batch_index=None,
+            prompt_text="prompt",
+            prompt_hash="abc",
+            raw_response="raw",
+            parsed_ok=True,
+        )
+        assert a.stage == "L2 stage_a"
+        assert a.batch_index is None
+        assert a.parsed_ok is True
+
+
+class TestEngineCaptureFlag:
+    def test_buffer_empty_when_capture_disabled(self):
+        client = MagicMock(spec=LLMClient)
+        client.invoke.side_effect = [
+            _stage_a(),
+            _stage_b_one_col("patient_id"),
+            _stage_b_one_col("age"),
+        ]
+        client.last_response = None
+        engine = SemanticEngine(
+            llm_client=client, run_id="r",
+            capture_llm_attempts=False,
+            column_batch_size=1,
+        )
+        engine.interpret_table(_meta())
+        assert engine.snapshot_llm_attempts() == []
+
+    def test_buffer_populated_for_successful_invocations(self):
+        client = MagicMock(spec=LLMClient)
+        client.invoke.side_effect = [
+            _stage_a(),
+            _stage_b_one_col("patient_id"),
+            _stage_b_one_col("age"),
+        ]
+        client.last_response = "raw text"
+        engine = SemanticEngine(
+            llm_client=client, run_id="r",
+            capture_llm_attempts=True,
+            column_batch_size=1,
+        )
+        engine.interpret_table(_meta())
+        snap = engine.snapshot_llm_attempts()
+        stages = [a.stage for a in snap]
+        assert "L2 stage_a" in stages
+        assert stages.count("L2 stage_b") >= 2
+        assert all(a.parsed_ok for a in snap)
+        assert all(a.prompt_text and a.prompt_hash for a in snap)
+
+    def test_buffer_records_failed_invocation(self):
+        """Failed invocation records parsed_ok=False with prompt + hash."""
+        client = MagicMock(spec=LLMClient)
+        client.invoke.side_effect = LLMStageError(
+            table_ref="r", stage_name="L2 stage_a",
+            step_errors=[("structured_output", ValueError("bad"))],
+        )
+        client.last_response = None
+        engine = SemanticEngine(
+            llm_client=client, run_id="r",
+            capture_llm_attempts=True,
+        )
+        with pytest.raises(LLMStageError):
+            engine.interpret_table(_meta())
+        snap = engine.snapshot_llm_attempts()
+        assert len(snap) >= 1
+        assert snap[-1].parsed_ok is False
+        assert snap[-1].stage == "L2 stage_a"
+        assert snap[-1].prompt_text
+
+    def test_buffer_reset_between_tables(self):
+        client = MagicMock(spec=LLMClient)
+        client.invoke.side_effect = [
+            _stage_a(), _stage_b_one_col("patient_id"), _stage_b_one_col("age"),
+            _stage_a(), _stage_b_one_col("patient_id"), _stage_b_one_col("age"),
+        ]
+        client.last_response = "raw"
+        engine = SemanticEngine(
+            llm_client=client, run_id="r",
+            capture_llm_attempts=True,
+            column_batch_size=1,
+        )
+        engine.interpret_table(_meta())
+        first_count = len(engine.snapshot_llm_attempts())
+        assert first_count > 0
+
+        engine.interpret_table(_meta())
+        second_count = len(engine.snapshot_llm_attempts())
+        # Each table populates from scratch; second table buffer reflects
+        # only its own invocations (not first + second).
+        assert second_count == first_count
+
+
+class TestStageBBatchIndexing:
+    def test_stage_b_attempts_have_batch_index(self):
+        client = MagicMock(spec=LLMClient)
+        client.invoke.side_effect = [
+            _stage_a(),
+            _stage_b_one_col("patient_id"),
+            _stage_b_one_col("age"),
+        ]
+        client.last_response = "raw"
+        engine = SemanticEngine(
+            llm_client=client, run_id="r",
+            capture_llm_attempts=True,
+            column_batch_size=1,
+        )
+        engine.interpret_table(_meta())
+        snap = engine.snapshot_llm_attempts()
+        b_attempts = [a for a in snap if a.stage == "L2 stage_b"]
+        # column_batch_size=1, two cols -> two batches with indices 0, 1
+        indices = [a.batch_index for a in b_attempts]
+        assert sorted(i for i in indices if i is not None) == [0, 1]
+
+
+class TestLLMClientLastResponseProperty:
+    def test_last_response_property_exposed(self):
+        from sema.llm_client import LLMClient
+
+        llm = MagicMock(spec=["invoke"])
+        response = MagicMock()
+        response.content = '{"vocabulary": "ICD-10"}'
+        llm.invoke.return_value = response
+
+        from sema.llm_client import VocabularyDetection
+        client = LLMClient(llm, retry_max_attempts=1)
+        client.invoke("p", VocabularyDetection)
+        # last_response should expose the raw model response
+        assert client.last_response is response

--- a/tests/unit/test_stage_b_failure_error.py
+++ b/tests/unit/test_stage_b_failure_error.py
@@ -1,0 +1,212 @@
+"""StageBFailureError carries staged context + llm_attempts (Section 4)."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from sema.engine.semantic import SemanticEngine, StageMetrics
+from sema.engine.semantic_utils import LLMAttempt
+from sema.llm_client import LLMClient, LLMStageError, StageBFailureError
+from sema.models.stages import (
+    StageAResult,
+    StageBBatchResult,
+    StageBColumnResult,
+    StageBCoverage,
+    StageBResult,
+    UnresolvedColumn,
+)
+
+
+def _cov(pct: float = 1.0) -> StageBCoverage:
+    return StageBCoverage(classified=int(pct * 10), total=10, pct=pct)
+
+pytestmark = pytest.mark.unit
+
+
+def _stage_a() -> StageAResult:
+    return StageAResult(
+        primary_entity="Patient",
+        grain_hypothesis="one row per patient",
+        confidence=0.9,
+    )
+
+
+def _meta() -> dict:
+    return {
+        "table_ref": "unity://cdm.clinical.patient",
+        "table_name": "patient",
+        "columns": [
+            {"name": "patient_id", "data_type": "STRING"},
+            {"name": "age", "data_type": "INTEGER"},
+        ],
+        "sample_rows": [],
+        "comment": None,
+    }
+
+
+class TestLLMStageErrorCarriesAttempts:
+    def test_default_llm_attempts_empty(self):
+        err = LLMStageError(
+            table_ref="r",
+            stage_name="L2 stage_a",
+            step_errors=[("structured_output", ValueError("bad"))],
+        )
+        assert err.llm_attempts == []
+
+    def test_can_attach_attempts(self):
+        att = LLMAttempt(
+            stage="L2 stage_a", batch_index=None,
+            prompt_text="p", prompt_hash="h",
+            raw_response=None, parsed_ok=False,
+        )
+        err = LLMStageError(
+            table_ref="r",
+            stage_name="L2 stage_a",
+            step_errors=[("structured_output", ValueError("bad"))],
+            llm_attempts=[att],
+        )
+        assert err.llm_attempts == [att]
+
+
+class TestStageBFailureError:
+    def test_is_a_llm_stage_error(self):
+        sa = _stage_a()
+        sb = StageBResult(
+            status="B_FAILED",
+            batch_results=[],
+            raw_coverage=_cov(0.5),
+            critical_coverage=_cov(1.0),
+            unresolved_columns=[],
+            retries_used=0,
+            splits_used=0,
+            rescues_used=0,
+        )
+        err = StageBFailureError(
+            table_ref="r",
+            stage_name="L2 stage_b",
+            step_errors=[("stage_b", ValueError("B_FAILED: raw=0.50"))],
+            stage_a=sa, stage_b=sb,
+            metrics=StageMetrics(),
+            llm_attempts=[],
+        )
+        assert isinstance(err, LLMStageError)
+
+    def test_carries_staged_context(self):
+        sa = _stage_a()
+        sb = StageBResult(
+            status="B_FAILED",
+            batch_results=[StageBBatchResult(columns=[
+                StageBColumnResult(
+                    column="patient_id",
+                    canonical_property_label="id",
+                    semantic_type="identifier",
+                    entity_role="primary_key",
+                    needs_stage_c=False,
+                ),
+            ])],
+            raw_coverage=_cov(0.5),
+            critical_coverage=_cov(1.0),
+            unresolved_columns=[
+                UnresolvedColumn(
+                    column="age", reason="execution_failure", tier="peripheral",
+                ),
+            ],
+            retries_used=1,
+            splits_used=0,
+            rescues_used=0,
+        )
+        m = StageMetrics(stage_a_latency_ms=10, stage_b_latency_ms=20)
+        att = LLMAttempt(
+            stage="L2 stage_b", batch_index=0,
+            prompt_text="p", prompt_hash="h",
+            raw_response="r", parsed_ok=False,
+        )
+        err = StageBFailureError(
+            table_ref="r",
+            stage_name="L2 stage_b",
+            step_errors=[("stage_b", ValueError("B_FAILED"))],
+            stage_a=sa, stage_b=sb, metrics=m,
+            llm_attempts=[att],
+        )
+        assert err.stage_a is sa
+        assert err.stage_b is sb
+        assert err.metrics is m
+        assert err.llm_attempts == [att]
+
+    def test_caught_by_existing_except_clause(self):
+        sa = _stage_a()
+        sb = StageBResult(
+            status="B_FAILED", batch_results=[],
+            raw_coverage=_cov(0.5), critical_coverage=_cov(1.0),
+            unresolved_columns=[], retries_used=0,
+            splits_used=0, rescues_used=0,
+        )
+        try:
+            raise StageBFailureError(
+                table_ref="r",
+                stage_name="L2 stage_b",
+                step_errors=[],
+                stage_a=sa, stage_b=sb,
+                metrics=StageMetrics(),
+                llm_attempts=[],
+            )
+        except LLMStageError as caught:
+            assert isinstance(caught, StageBFailureError)
+
+
+class TestEngineRaisesStageBFailureError:
+    def test_synthetic_b_failed_raises_stage_b_failure_error(self):
+        client = MagicMock(spec=LLMClient)
+        client.invoke.side_effect = [
+            _stage_a(),
+            StageBBatchResult(columns=[
+                StageBColumnResult(
+                    column="patient_id",
+                    canonical_property_label="id",
+                    semantic_type="identifier",
+                    entity_role="primary_key",
+                    needs_stage_c=False,
+                ),
+            ]),
+            # Second batch returns no cols -> raw coverage drops -> B_FAILED
+            StageBBatchResult(columns=[]),
+        ]
+        client.last_response = None
+        engine = SemanticEngine(
+            llm_client=client, run_id="r",
+            capture_llm_attempts=True,
+            column_batch_size=1,
+        )
+        with pytest.raises(StageBFailureError) as exc_info:
+            engine.interpret_table_staged_with_metrics(_meta())
+
+        err = exc_info.value
+        assert err.stage_a is not None
+        assert err.stage_b is not None
+        assert err.stage_b.status == "B_FAILED"
+        assert err.metrics is not None
+        # attempts include stage_a + stage_b batches
+        stages = [a.stage for a in err.llm_attempts]
+        assert "L2 stage_a" in stages
+        assert "L2 stage_b" in stages
+
+    def test_stage_a_failure_carries_attempts_on_llm_stage_error(self):
+        client = MagicMock(spec=LLMClient)
+        client.invoke.side_effect = LLMStageError(
+            table_ref="r", stage_name="L2 stage_a",
+            step_errors=[("structured_output", ValueError("bad"))],
+        )
+        client.last_response = None
+        engine = SemanticEngine(
+            llm_client=client, run_id="r",
+            capture_llm_attempts=True,
+        )
+        with pytest.raises(LLMStageError) as exc_info:
+            engine.interpret_table_staged_with_metrics(_meta())
+
+        err = exc_info.value
+        # Engine attaches the attempt buffer at every raise site
+        assert len(err.llm_attempts) >= 1
+        assert err.llm_attempts[0].stage == "L2 stage_a"
+        assert err.llm_attempts[0].parsed_ok is False


### PR DESCRIPTION
## Summary

Stage-B failure containment work — six sections that change how the build pipeline classifies, recovers from, and persists evidence about failures during semantic interpretation:

- **Circuit breaker — service-health-only classification** (`§1`). The breaker only trips on transport / 5xx failures; rate limits, JSON parse errors, Pydantic validation errors, and universal-parser ValueErrors no longer trigger cascade-skips of healthy tables.
- **Resume gating** (`§2`). `--resume` now preserves prior assertions instead of running the schema-wipe loop. Verified on the populated graph: 37/37 tables marked `skipped`, assertions 6962→6962.
- **Engine-local LLM-attempt buffer** (`§3`). Opt-in (gated on `eval_dump_dir`), reset per table, populated for both successful and failed batch invocations.
- **`StageBFailureError` carries staged context** (`§4`). New typed exception subclass of `LLMStageError` carrying `stage_a`, `stage_b`, `metrics`, and `llm_attempts` so the failure-artifact writer reads everything off the exception — no engine reference required from the worker.
- **Forensic artifact persistence** (`§5`). `<table>__<label>__failure.json` written on every failure path (Stage A failure, B_FAILED, circuit-open). Captures every `LLMClient.invoke` call across stages including failed batches; classification taxonomy aligned with the breaker.
- **Metadata-availability policy + `B_PARTIAL` outcome** (`§5b`). New `metadata_tier` classifier (`rich` / `sparse` / `name_only`) computed before Stage A so the tier is on every failure artifact. Tier-keyed `B_PARTIAL` admission floor — rich tables stay at 0.75; sparse / name_only get a lowered floor (default 0.60) so partial commits are admitted instead of failing a coverage-floor check the source can't meet.
- **Run-level quality budget** (`§6`). Two triggers: `stage_b_failure_rate` (default 30%) and `run_non_contributing_rate` (default 40%). Resume-skipped tables count toward the graph-contributing denominator but not the non-contributing trigger. `--no-quality-budget` disables both ceilings; `QualityBudgetExceeded` exits with code 7.

## Verification

- `uv run pytest -q` — 1351 passed / 1 skipped / 38 deselected
- `uv run mypy src/sema/` — clean across 112 files
- Coverage 89% (`quality_budget.py` 100%) — gate ≥85%
- Live resume smoke against the populated graph (`.runs/build_resume_smoke_20260505_163145.log`): 37/37 skipped, no circuit-breaker skips on healthy LLM, no quality-budget abort, assertions preserved
- Deliberate-failure smoke for the forensic artifact: `step_errors[].exception_type` discriminates `JSONDecodeError` vs `ValidationError` within the `content_failure` classification; `llm_attempts` carries failed-batch prompt text; both `StageBFailureError` (→ semantic_coverage) and plain `LLMStageError` (→ content_failure) paths verified

## Related issues

- Related to #72 (full 33-table cBioPortal corpus sign-off — blocked on ingest). Today's verification exercised the full 37-table corpus across `cbioportal_gbm_tcga_pan_can_atlas_2018` + `cbioportal_msk_chord_2024`; bias check + sign-off still owed under that issue.
- Related to #81 (Databricks GPT-5.x endpoints unblock + re-run eval Measurement A). Confirms the AI Gateway and `54mini` endpoint are reachable from `sema`'s `provider=custom` code path; Measurement A re-run still owed under that issue.

## Follow-ups surfaced by this PR

- #91 — regenerate `.wolf/anatomy.md` to cover src/ and tests/ trees (scanner scope misconfiguration)
- #92 — optionally split this PR's bundled commit into 7 conventional commits (review-time decision)
- #93 — investigate sparse-tier dominance on cBioPortal source contract (24/26 tables landed `sparse`)
- #94 — rate-limit L3 column LLM calls to stay under gateway RPM cap (26+ 429s observed at 1 worker)
- #95 — implement self-verification stage in L2 hybrid prompting (vision coverage at 3/5 hybrid techniques)

## Test plan

- [x] `uv run pytest -q` green locally
- [x] `uv run mypy src/sema/` clean locally
- [x] Coverage ≥85% locally
- [x] Resume smoke (assertion preservation, no cascade skips, no premature quality-budget abort)
- [x] Deliberate-failure smoke (artifact completeness + step_errors sub-type discrimination)
- [x] CI green on this PR